### PR TITLE
fix: Module Not Found Error

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -3,5 +3,5 @@ module.exports = {
     siteUrl: 'https://www.yourdomain.tld',
     title: 'Jeonghye Blog',
   },
-  plugins: ['gatsby-plugin-typescript'],
+  plugins: ['gatsby-plugin-typescript', 'gatsby-plugin-root-import'],
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "eslint-plugin-prettier": "^4.0.0",
         "eslint-plugin-react": "^7.28.0",
         "eslint-plugin-react-hooks": "^4.3.0",
+        "gatsby-plugin-root-import": "^2.0.8",
         "husky": "^7.0.4",
         "lint-staged": "^12.1.4",
         "prettier": "^2.5.1",
@@ -8581,6 +8582,15 @@
       },
       "peerDependencies": {
         "gatsby": "^4.0.0-next"
+      }
+    },
+    "node_modules/gatsby-plugin-root-import": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-root-import/-/gatsby-plugin-root-import-2.0.8.tgz",
+      "integrity": "sha512-y07q3c+Pz1qoW3XdkAvl5PbO2+gc0GhcfZYq+Msw2JBe5M+FSByhQVDhZYCVMRVZz0qx6L4qr3w3i04/k4S2HA==",
+      "dev": true,
+      "peerDependencies": {
+        "gatsby": "^2 || ^3 || ^4"
       }
     },
     "node_modules/gatsby-plugin-typescript": {
@@ -24830,6 +24840,13 @@
         "globby": "^11.0.4",
         "lodash": "^4.17.21"
       }
+    },
+    "gatsby-plugin-root-import": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-root-import/-/gatsby-plugin-root-import-2.0.8.tgz",
+      "integrity": "sha512-y07q3c+Pz1qoW3XdkAvl5PbO2+gc0GhcfZYq+Msw2JBe5M+FSByhQVDhZYCVMRVZz0qx6L4qr3w3i04/k4S2HA==",
+      "dev": true,
+      "requires": {}
     },
     "gatsby-plugin-typescript": {
       "version": "4.4.0",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "eslint-plugin-prettier": "^4.0.0",
     "eslint-plugin-react": "^7.28.0",
     "eslint-plugin-react-hooks": "^4.3.0",
+    "gatsby-plugin-root-import": "^2.0.8",
     "husky": "^7.0.4",
     "lint-staged": "^12.1.4",
     "prettier": "^2.5.1",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,7 +17,5 @@
     "noEmit": true,
     "jsx": "react-jsx",
     "baseUrl": "./src"
-  },
-  "include": ["src/**/*"],
-  "exclude": ["node_modules", "public", ".cache"]
+  }
 }


### PR DESCRIPTION
# What is this PR? 🔍

### Problem
import module을 절대경로로 쓸 수 있게 하려했는데,
`tsconfig.json`에 `baseUrl` 설정만으로는 모듈을 찾지 못했다.

```bash
ModuleNotFoundError: Module not found: Error: Can't resolve ... 
```
### Solution
gatsby plugin 인 `gatsbt-plugin-root-import`를 설치해서 해결

