### PR TITLE
fix: CSS 중복 적용 문제

### DIFF
--- a/src/components/PhotoCard/index.tsx
+++ b/src/components/PhotoCard/index.tsx
@@ -15,7 +15,7 @@ function PhotoCard(props: PhotoCardProps) {
   const thumbnail = getImage(props.thumbnail);
 
   return (
-    <Link to={`/${link}`} className="card">
+    <Link to={`/${link}`} className="photocard">
       {thumbnail && <GatsbyImage image={thumbnail} alt="thumbnail" />}
       <div className="title">{title}</div>
       <div className="date">{date}</div>

--- a/src/components/PhotoCard/photocard.scss
+++ b/src/components/PhotoCard/photocard.scss
@@ -1,6 +1,6 @@
 @import 'utils/variables.scss';
 
-.card {
+.photocard {
   .gatsby-image-wrapper {
     width: 100%;
   }

--- a/src/containers/Dev/DevContent/devContent.scss
+++ b/src/containers/Dev/DevContent/devContent.scss
@@ -1,6 +1,6 @@
 @import 'utils/variables.scss';
 
-.content {
+.dev-content {
   display: grid;
   grid-template-columns: repeat(3, 1fr);
   gap: 40px 20px;

--- a/src/containers/Dev/DevContent/index.tsx
+++ b/src/containers/Dev/DevContent/index.tsx
@@ -34,7 +34,7 @@ function DevContent(props: DevContentProps) {
   );
 
   return (
-    <section className="content">
+    <section className="dev-content">
       {filteredPosts.map(
         ({ node: { id, frontmatter, slug } }: PostsEdgeType) => (
           <PhotoCard key={id} id={id} link={slug} {...frontmatter} />

--- a/src/containers/Write/WriteContent/index.tsx
+++ b/src/containers/Write/WriteContent/index.tsx
@@ -31,7 +31,7 @@ function WriteContent(props: WriteContentProps) {
   );
 
   return (
-    <section className="content">
+    <section className="write-content">
       {filteredPosts.map(
         ({ node: { id, frontmatter, slug } }: PostsEdgeType) => (
           <PhotoCard key={id} id={id} link={slug} {...frontmatter} />

--- a/src/containers/Write/WriteContent/writeContent.scss
+++ b/src/containers/Write/WriteContent/writeContent.scss
@@ -1,6 +1,6 @@
 @import 'utils/variables.scss';
 
-.content {
+.write-content {
   display: grid;
   grid-template-columns: repeat(3, 1fr);
   gap: 40px 20px;


### PR DESCRIPTION
## What is this PR? 🔍

classname으로 구분했던 css가 충돌하는 문제가 발생했다.
scss를 사용해서 module로 적용할 파일에만 Import해주면 같은 이름을 사용해도 괜찮을거라고 생각했는데, 중복으로 적용되었다.

해당 문제를 해결하기 위해서 일단 classname을 변경했다.

## Issues
#61