### PR TITLE
fix: 이미지 크기가 안맞는 문제 발생

### DIFF
--- a/src/components/PhotoCard/photocard.scss
+++ b/src/components/PhotoCard/photocard.scss
@@ -3,24 +3,25 @@
 .photocard {
   .gatsby-image-wrapper {
     width: 100%;
+
+    img {
+      background: #c4c4c4;
+      border-radius: 5px;
+      width: 100%;
+      height: 15vw;
+      margin-bottom: 15px;
+      object-fit: cover;
+
+      @media screen and (max-width: $break-m) {
+        height: 25vw;
+      }
+
+      @media screen and (max-width: $break-s) {
+        height: 50vw;
+      }
+    }
   }
 
-  img {
-    background: #c4c4c4;
-    border-radius: 5px;
-    width: 100%;
-    height: 15vw;
-    margin-bottom: 15px;
-    object-fit: cover;
-
-    @media screen and (max-width: $break-m) {
-      height: 25vw;
-    }
-
-    @media screen and (max-width: $break-s) {
-      height: 50vw;
-    }
-  }
   .title {
     font-family: 'Nunito Sans';
     font-size: 1.25rem;


### PR DESCRIPTION
## What is this PR? 🔍

이미지 크기가 적용이 안되는 경우가 발생했다.
<img width="600" alt="image" src="https://user-images.githubusercontent.com/54584063/170877788-2b3aca8a-365e-436d-b6a3-088509a04919.png">

### Solved
알고보니 gatsby image 태그 중 `.gatsby-image-wrapper img` 에 `height: 100%`가 적용되어 있었다. 
그래서 썸네일 `img` 스타일 적용 부분을 `.gatsby-image-wrapper  > img`로 변경했다.

## Issues

#66