### PR TITLE
fix: Please rename "gatsby-config.ts" to "gatsby-config.js"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@fortawesome/react-fontawesome": "^0.1.16",
         "@mdx-js/mdx": "^1.6.22",
         "@mdx-js/react": "^1.6.22",
-        "gatsby": "^4.4.0",
+        "gatsby": "^4.9.0",
         "gatsby-plugin-canonical-urls": "^4.11.0",
         "gatsby-plugin-disqus": "^1.2.3",
         "gatsby-plugin-google-fonts": "^1.0.1",
@@ -3079,6 +3079,19 @@
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
+    "node_modules/@lezer/common": {
+      "version": "0.15.12",
+      "resolved": "https://registry.npmjs.org/@lezer/common/-/common-0.15.12.tgz",
+      "integrity": "sha512-edfwCxNLnzq5pBA/yaIhwJ3U3Kz8VAUOTRg0hhxaizaI1N+qxV7EXDv/kLCkLeq2RzSFvxexlaj5Mzfn2kY0Ig=="
+    },
+    "node_modules/@lezer/lr": {
+      "version": "0.15.8",
+      "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-0.15.8.tgz",
+      "integrity": "sha512-bM6oE6VQZ6hIFxDNKk8bKPa14hqFrV07J/vHGOeiAbJReIaQXmkVb6xQu4MR+JBTLa5arGRyAAjJe1qaQt3Uvg==",
+      "dependencies": {
+        "@lezer/common": "^0.15.0"
+      }
+    },
     "node_modules/@mdx-js/mdx": {
       "version": "1.6.22",
       "resolved": "https://registry.npmjs.org/@mdx-js/mdx/-/mdx-1.6.22.tgz",
@@ -3173,6 +3186,19 @@
       "resolved": "https://registry.npmjs.org/@microsoft/fetch-event-source/-/fetch-event-source-2.0.1.tgz",
       "integrity": "sha512-W6CLUJ2eBMw3Rec70qrsEW0jOm/3twwJv21mrmj2yORiaVmVYGS4sSS5yUwvQc1ZlDLYGPnClVWmUUMagKNsfA=="
     },
+    "node_modules/@mischnic/json-sourcemap": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@mischnic/json-sourcemap/-/json-sourcemap-0.1.0.tgz",
+      "integrity": "sha512-dQb3QnfNqmQNYA4nFSN/uLaByIic58gOXq4Y4XqLOWmOrw73KmJPt/HLyG0wvn1bnR6mBKs/Uwvkh+Hns1T0XA==",
+      "dependencies": {
+        "@lezer/common": "^0.15.7",
+        "@lezer/lr": "^0.15.4",
+        "json5": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -3206,19 +3232,19 @@
       }
     },
     "node_modules/@parcel/bundler-default": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@parcel/bundler-default/-/bundler-default-2.4.1.tgz",
-      "integrity": "sha512-PTfBOuoiiYdfwyoPFeBTOinyl1RL4qaoyAQ0PCe01C1i4NcRWCY1w7zRvwJW/OhU3Ka+LtioGmfxu5/drdXzLg==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/bundler-default/-/bundler-default-2.6.0.tgz",
+      "integrity": "sha512-AplEdGm/odV7yGmoeOnglxnY31WlNB5EqGLFGxkgs7uwDaTWoTX/9SWPG6xfvirhjDpms8sLSiVuBdFRCCLtNA==",
       "dependencies": {
-        "@parcel/diagnostic": "2.4.1",
-        "@parcel/hash": "2.4.1",
-        "@parcel/plugin": "2.4.1",
-        "@parcel/utils": "2.4.1",
+        "@parcel/diagnostic": "2.6.0",
+        "@parcel/hash": "2.6.0",
+        "@parcel/plugin": "2.6.0",
+        "@parcel/utils": "2.6.0",
         "nullthrows": "^1.1.1"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.4.1"
+        "parcel": "^2.6.0"
       },
       "funding": {
         "type": "opencollective",
@@ -3226,14 +3252,14 @@
       }
     },
     "node_modules/@parcel/cache": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@parcel/cache/-/cache-2.4.1.tgz",
-      "integrity": "sha512-2N5ly++p/yefmPdK39X1QIoA2e6NtS1aYSsxrIC9EX92Kjd7SfSceqUJhlJWB49omJSheEJLd1qM3EJG9EvICQ==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/cache/-/cache-2.6.0.tgz",
+      "integrity": "sha512-4vbD5uSuf+kRnrFesKhpn0AKnOw8u2UlvCyrplYmp1g9bNAkIooC/nDGdmkb/9SviPEbni9PEanQEHDU2+slpA==",
       "dependencies": {
-        "@parcel/fs": "2.4.1",
-        "@parcel/logger": "2.4.1",
-        "@parcel/utils": "2.4.1",
-        "lmdb": "2.2.4"
+        "@parcel/fs": "2.6.0",
+        "@parcel/logger": "2.6.0",
+        "@parcel/utils": "2.6.0",
+        "lmdb": "2.3.10"
       },
       "engines": {
         "node": ">= 12.0.0"
@@ -3243,26 +3269,13 @@
         "url": "https://opencollective.com/parcel"
       },
       "peerDependencies": {
-        "@parcel/core": "^2.4.1"
-      }
-    },
-    "node_modules/@parcel/cache/node_modules/lmdb": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/lmdb/-/lmdb-2.2.4.tgz",
-      "integrity": "sha512-gto+BB2uEob8qRiTlOq+R3uX0YNHsX9mjxj9Sbdue/LIKqu6IlZjrsjKeGyOMquc/474GEqFyX2pdytpydp0rQ==",
-      "hasInstallScript": true,
-      "dependencies": {
-        "msgpackr": "^1.5.4",
-        "nan": "^2.14.2",
-        "node-gyp-build": "^4.2.3",
-        "ordered-binary": "^1.2.4",
-        "weak-lru-cache": "^1.2.2"
+        "@parcel/core": "^2.6.0"
       }
     },
     "node_modules/@parcel/codeframe": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@parcel/codeframe/-/codeframe-2.4.1.tgz",
-      "integrity": "sha512-m3WDeEpWvgqekCqsHfPMJrSQquahdIgSR1x1RDCqQ1YelvW0fQiGgu42MXI5tjoBrHC1l1mF01UDb+xMSxz1DA==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/codeframe/-/codeframe-2.6.0.tgz",
+      "integrity": "sha512-yXXxrO9yyedHKpTwC+Af0+vPmQm+A9xeEhkt4f0yVg1n4t4yUIxYlTedzbM8ygZEEBtkXU9jJ+PkgXbfMf0dqw==",
       "dependencies": {
         "chalk": "^4.1.0"
       },
@@ -3339,15 +3352,15 @@
       }
     },
     "node_modules/@parcel/compressor-raw": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@parcel/compressor-raw/-/compressor-raw-2.4.1.tgz",
-      "integrity": "sha512-cEOOOzIK7glxCqJX0OfBFBZE/iT7tmjEOXswRY3CnqY9FGoY3NYDAsOLm7A73RuIdNaZfYVxVUy3g7OLpbKL+g==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/compressor-raw/-/compressor-raw-2.6.0.tgz",
+      "integrity": "sha512-rtMU2mGl88bic6Xbq1u5L49bMK4s5185b0k7h3JRdS6/0rR+Xp4k/o9Wog+hHjK/s82z1eF9WmET779ZpIDIQQ==",
       "dependencies": {
-        "@parcel/plugin": "2.4.1"
+        "@parcel/plugin": "2.6.0"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.4.1"
+        "parcel": "^2.6.0"
       },
       "funding": {
         "type": "opencollective",
@@ -3355,30 +3368,30 @@
       }
     },
     "node_modules/@parcel/core": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@parcel/core/-/core-2.4.1.tgz",
-      "integrity": "sha512-h2FvqLA75ZQdIXX1y+ylGjIIi7YtbAUJyIapxaO081h3EsYG2jr9sRL4sym5ECgmvbyua/DEgtMLX3eGYn09FA==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/core/-/core-2.6.0.tgz",
+      "integrity": "sha512-8OOWbPuxpFydpwNyKoz6d3e3O4DmxNYmMw4DXwrPSj/jyg7oa+SDtMT0/VXEhujE0HYkQPCHt4npRajkSuf99A==",
       "dependencies": {
-        "@parcel/cache": "2.4.1",
-        "@parcel/diagnostic": "2.4.1",
-        "@parcel/events": "2.4.1",
-        "@parcel/fs": "2.4.1",
-        "@parcel/graph": "2.4.1",
-        "@parcel/hash": "2.4.1",
-        "@parcel/logger": "2.4.1",
-        "@parcel/package-manager": "2.4.1",
-        "@parcel/plugin": "2.4.1",
+        "@mischnic/json-sourcemap": "^0.1.0",
+        "@parcel/cache": "2.6.0",
+        "@parcel/diagnostic": "2.6.0",
+        "@parcel/events": "2.6.0",
+        "@parcel/fs": "2.6.0",
+        "@parcel/graph": "2.6.0",
+        "@parcel/hash": "2.6.0",
+        "@parcel/logger": "2.6.0",
+        "@parcel/package-manager": "2.6.0",
+        "@parcel/plugin": "2.6.0",
         "@parcel/source-map": "^2.0.0",
-        "@parcel/types": "2.4.1",
-        "@parcel/utils": "2.4.1",
-        "@parcel/workers": "2.4.1",
+        "@parcel/types": "2.6.0",
+        "@parcel/utils": "2.6.0",
+        "@parcel/workers": "2.6.0",
         "abortcontroller-polyfill": "^1.1.9",
         "base-x": "^3.0.8",
         "browserslist": "^4.6.6",
         "clone": "^2.1.1",
         "dotenv": "^7.0.0",
         "dotenv-expand": "^5.1.0",
-        "json-source-map": "^0.6.1",
         "json5": "^2.2.0",
         "msgpackr": "^1.5.4",
         "nullthrows": "^1.1.1",
@@ -3409,11 +3422,11 @@
       }
     },
     "node_modules/@parcel/diagnostic": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@parcel/diagnostic/-/diagnostic-2.4.1.tgz",
-      "integrity": "sha512-wmJIfn0PG2ABuraS+kMjl6UKaLjTDTtG+XkjJLWHzU/dd5RozqAZDKp65GWjvHzHLx7KICTAdUJsXh2s3TnTOQ==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/diagnostic/-/diagnostic-2.6.0.tgz",
+      "integrity": "sha512-+p8gC2FKxSI2veD7SoaNlP572v4kw+nafCQEPDtJuzYYRqywYUGncch25dkpgNApB4W4cXVkZu3ZbtIpCAmjQQ==",
       "dependencies": {
-        "json-source-map": "^0.6.1",
+        "@mischnic/json-sourcemap": "^0.1.0",
         "nullthrows": "^1.1.1"
       },
       "engines": {
@@ -3425,9 +3438,9 @@
       }
     },
     "node_modules/@parcel/events": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@parcel/events/-/events-2.4.1.tgz",
-      "integrity": "sha512-er2jwyzYt3Zimkrp7TR865GIeIMYNd7YSSxW39y/egm4LIPBsruUpHSnKRD5b65Jd+gckkxDsnrpADG6MH1zNw==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/events/-/events-2.6.0.tgz",
+      "integrity": "sha512-2WaKtBs4iYwS88j4zRdyTJTgh8iuY4E32FMmjzzbheqETs6I05gWuPReGukJYxk8vc0Ir7tbzp12oAfpgo0Y+g==",
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -3437,15 +3450,15 @@
       }
     },
     "node_modules/@parcel/fs": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@parcel/fs/-/fs-2.4.1.tgz",
-      "integrity": "sha512-kE9HzW6XjO/ZA5bQnAzp1YVmGlXeDqUaius2cH2K0wU7KQX/GBjyfEWJm/UsKPB6QIrGXgkPH6ashNzOgwDqpw==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/fs/-/fs-2.6.0.tgz",
+      "integrity": "sha512-6vxtx5Zy6MvDvH1EPx9JxjKGF03bR7VE1dUf4HLeX2D8YmpL5hkHJnlRCFdcH08rzOVwaJLzg1QNtblWJXQ9CA==",
       "dependencies": {
-        "@parcel/fs-search": "2.4.1",
-        "@parcel/types": "2.4.1",
-        "@parcel/utils": "2.4.1",
+        "@parcel/fs-search": "2.6.0",
+        "@parcel/types": "2.6.0",
+        "@parcel/utils": "2.6.0",
         "@parcel/watcher": "^2.0.0",
-        "@parcel/workers": "2.4.1"
+        "@parcel/workers": "2.6.0"
       },
       "engines": {
         "node": ">= 12.0.0"
@@ -3455,13 +3468,13 @@
         "url": "https://opencollective.com/parcel"
       },
       "peerDependencies": {
-        "@parcel/core": "^2.4.1"
+        "@parcel/core": "^2.6.0"
       }
     },
     "node_modules/@parcel/fs-search": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@parcel/fs-search/-/fs-search-2.4.1.tgz",
-      "integrity": "sha512-xfoLvHjHkZm4VZf3UWU5v6gzz+x7IBVY7siHGn0YyGwvlv73FmiR4mCSizqerXOyXknF2fpg6tNHNQyyNLS32Q==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/fs-search/-/fs-search-2.6.0.tgz",
+      "integrity": "sha512-1nXzM3H/cA4kzLKvDBvwmNisKCdRqlgkLXh+OR1Zu28Kn4W34KuJMcHWW8cC+WIuuKqDh5oo2WPsC5y65GXBKQ==",
       "dependencies": {
         "detect-libc": "^1.0.3"
       },
@@ -3474,11 +3487,11 @@
       }
     },
     "node_modules/@parcel/graph": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@parcel/graph/-/graph-2.4.1.tgz",
-      "integrity": "sha512-3JCnPI9BJdKpGIk6NtVN7ML3C/J9Ey+WfUfk8WisDxFP7vjYkXwZbNSR/HnxH+Y03wmB6cv4HI8A4kndF0H0pw==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/graph/-/graph-2.6.0.tgz",
+      "integrity": "sha512-rxrAzWm6rwbCRPbu0Z+zwMscpG8omffODniVWPlX2G0jgQGpjKsutBQ6RMfFIcfaQ4MzL3pIQOTf8bkjQOPsbg==",
       "dependencies": {
-        "@parcel/utils": "2.4.1",
+        "@parcel/utils": "2.6.0",
         "nullthrows": "^1.1.1"
       },
       "engines": {
@@ -3490,9 +3503,9 @@
       }
     },
     "node_modules/@parcel/hash": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@parcel/hash/-/hash-2.4.1.tgz",
-      "integrity": "sha512-Ch1kkFPedef3geapU+XYmAdZY29u3eQXn/twMjowAKkWCmj6wZ+muUgBmOO2uCfK3xys7GycI8jYZcAbF5DVLg==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/hash/-/hash-2.6.0.tgz",
+      "integrity": "sha512-YugWqhLxqK80Lo++3B3Kr5UPCHOdS8iI2zJ1jkzUeH9v6WUzbwWOnmPf6lN2S5m1BrIFFJd8Jc+CbEXWi8zoJA==",
       "dependencies": {
         "detect-libc": "^1.0.3",
         "xxhash-wasm": "^0.4.2"
@@ -3506,12 +3519,12 @@
       }
     },
     "node_modules/@parcel/logger": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.4.1.tgz",
-      "integrity": "sha512-wm7FoKY+1dyo+Dd7Z4b0d6hmpgRBWfZwCoZSSyhgbG96Ty68/oo3m7oEMXPfry8IVGIhShmWKDp4py44PH3l7w==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.6.0.tgz",
+      "integrity": "sha512-J1/7kPfSGBvMKSZdi0WCNuN0fIeiWxifnDGn7W/K8KhD422YwFJA8N046ps8nkDOPIXf1osnIECNp4GIR9oSYw==",
       "dependencies": {
-        "@parcel/diagnostic": "2.4.1",
-        "@parcel/events": "2.4.1"
+        "@parcel/diagnostic": "2.6.0",
+        "@parcel/events": "2.6.0"
       },
       "engines": {
         "node": ">= 12.0.0"
@@ -3522,9 +3535,9 @@
       }
     },
     "node_modules/@parcel/markdown-ansi": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@parcel/markdown-ansi/-/markdown-ansi-2.4.1.tgz",
-      "integrity": "sha512-BkWhzbKQhTQ9lS96ZMMG0KyXSJBFdNeBVobWrdrrwcFlNER0nt2m6fdF7Hfpf1TqFhM4tT+GNFtON7ybL53RiQ==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/markdown-ansi/-/markdown-ansi-2.6.0.tgz",
+      "integrity": "sha512-fyjkrJQQSfKTUFTTasdZ6WrAkDoQ2+DYDjj+3p+RncYyrIa9zArKx4IiRiipsvNdtMvP0/hTdK8F3BOJ3KSU/g==",
       "dependencies": {
         "chalk": "^4.1.0"
       },
@@ -3601,17 +3614,17 @@
       }
     },
     "node_modules/@parcel/namer-default": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@parcel/namer-default/-/namer-default-2.4.1.tgz",
-      "integrity": "sha512-a/Xulfia7JJP6Cw/D6Wq5xX6IAKVKMRPEYtU2wB8vKuwC/et6kXi+0bFVeCLnTjDzVtsjDdyOEwfRC4yiEy3BA==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/namer-default/-/namer-default-2.6.0.tgz",
+      "integrity": "sha512-r8O12r7ozJBctnFxVdXbf/fK97GIdNj3hiiUNWlXEmED9sw6ZPcChaLcfot0/443g8i87JDmSTKJ8js2tuz5XA==",
       "dependencies": {
-        "@parcel/diagnostic": "2.4.1",
-        "@parcel/plugin": "2.4.1",
+        "@parcel/diagnostic": "2.6.0",
+        "@parcel/plugin": "2.6.0",
         "nullthrows": "^1.1.1"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.4.1"
+        "parcel": "^2.6.0"
       },
       "funding": {
         "type": "opencollective",
@@ -3619,12 +3632,12 @@
       }
     },
     "node_modules/@parcel/node-resolver-core": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@parcel/node-resolver-core/-/node-resolver-core-2.4.1.tgz",
-      "integrity": "sha512-CvCADj3l4o5USqz/ZCaqbK8gdAQK63q94oSa0KnP6hrcDI/gDyf5Bk4+3cD4kSI+ByuN6aFLAYBS2nHBh5O/MQ==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/node-resolver-core/-/node-resolver-core-2.6.0.tgz",
+      "integrity": "sha512-AJDj5DZbB58plv0li8bdVSD+zpnkHE36Om3TYyNn1jgXXwgBM64Er/9p8yQn356jBqTQMh7zlJqvbdIyOiMeMg==",
       "dependencies": {
-        "@parcel/diagnostic": "2.4.1",
-        "@parcel/utils": "2.4.1",
+        "@parcel/diagnostic": "2.6.0",
+        "@parcel/utils": "2.6.0",
         "nullthrows": "^1.1.1"
       },
       "engines": {
@@ -3636,20 +3649,20 @@
       }
     },
     "node_modules/@parcel/optimizer-terser": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@parcel/optimizer-terser/-/optimizer-terser-2.4.1.tgz",
-      "integrity": "sha512-naRdp6gApWHUI1FCBZEJs9NzNngjZx8hRhIHeQtTxWpc2Mu8cVzxbVHNAwUj10nW3iOYmxyj4wleOArl8xpVCQ==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/optimizer-terser/-/optimizer-terser-2.6.0.tgz",
+      "integrity": "sha512-oezRt6Lz/QqcVDXyMfFjzQc7n0ThJowLJ4Lyhu8rMh0ZJYzc4UCFCw/19d4nRnzE+Qg0vj3mQCpdkA9/64E44g==",
       "dependencies": {
-        "@parcel/diagnostic": "2.4.1",
-        "@parcel/plugin": "2.4.1",
+        "@parcel/diagnostic": "2.6.0",
+        "@parcel/plugin": "2.6.0",
         "@parcel/source-map": "^2.0.0",
-        "@parcel/utils": "2.4.1",
+        "@parcel/utils": "2.6.0",
         "nullthrows": "^1.1.1",
         "terser": "^5.2.0"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.4.1"
+        "parcel": "^2.6.0"
       },
       "funding": {
         "type": "opencollective",
@@ -3657,16 +3670,16 @@
       }
     },
     "node_modules/@parcel/package-manager": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@parcel/package-manager/-/package-manager-2.4.1.tgz",
-      "integrity": "sha512-JUUinm4U3hy4epHl9A389xb+BGiFR8n9+qw3Z4UDfS1te43sh8+0virBGcnai/G7mlr5/vHW+l9xulc7WQaY6w==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/package-manager/-/package-manager-2.6.0.tgz",
+      "integrity": "sha512-AqFfdkbOw51q/3ia2mIsFTmrpYEyUb3k+2uYC5GsLMz3go6OGn7/Crz0lZLSclv5EtwpRg3TWr9yL7RekVN/Uw==",
       "dependencies": {
-        "@parcel/diagnostic": "2.4.1",
-        "@parcel/fs": "2.4.1",
-        "@parcel/logger": "2.4.1",
-        "@parcel/types": "2.4.1",
-        "@parcel/utils": "2.4.1",
-        "@parcel/workers": "2.4.1",
+        "@parcel/diagnostic": "2.6.0",
+        "@parcel/fs": "2.6.0",
+        "@parcel/logger": "2.6.0",
+        "@parcel/types": "2.6.0",
+        "@parcel/utils": "2.6.0",
+        "@parcel/workers": "2.6.0",
         "semver": "^5.7.1"
       },
       "engines": {
@@ -3677,7 +3690,7 @@
         "url": "https://opencollective.com/parcel"
       },
       "peerDependencies": {
-        "@parcel/core": "^2.4.1"
+        "@parcel/core": "^2.6.0"
       }
     },
     "node_modules/@parcel/package-manager/node_modules/semver": {
@@ -3689,21 +3702,21 @@
       }
     },
     "node_modules/@parcel/packager-js": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@parcel/packager-js/-/packager-js-2.4.1.tgz",
-      "integrity": "sha512-broWBUQisJLF5ThFtnl/asypuLMlMBwFPBTr8Ho9FYlL6W4wUzIymu7eOcuDljstmbD6luNVGMdCBYqt3IhHmw==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/packager-js/-/packager-js-2.6.0.tgz",
+      "integrity": "sha512-Uz3pqIFchFfKszWnNGDgIwM1uwHHJp7Dts6VzS9lf/2RbRgZT0fmce+NPgnVO5MMKBHzdvm32ShT6gFAABF5Vw==",
       "dependencies": {
-        "@parcel/diagnostic": "2.4.1",
-        "@parcel/hash": "2.4.1",
-        "@parcel/plugin": "2.4.1",
+        "@parcel/diagnostic": "2.6.0",
+        "@parcel/hash": "2.6.0",
+        "@parcel/plugin": "2.6.0",
         "@parcel/source-map": "^2.0.0",
-        "@parcel/utils": "2.4.1",
+        "@parcel/utils": "2.6.0",
         "globals": "^13.2.0",
         "nullthrows": "^1.1.1"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.4.1"
+        "parcel": "^2.6.0"
       },
       "funding": {
         "type": "opencollective",
@@ -3711,9 +3724,9 @@
       }
     },
     "node_modules/@parcel/packager-js/node_modules/globals": {
-      "version": "13.13.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-13.13.0.tgz",
-      "integrity": "sha512-EQ7Q18AJlPwp3vUDL4mKA0KXrXyNIQyWon6T6XQiBQF0XHvRsiCSrWmmeATpUzdJN2HhWZU6Pdl0a9zdep5p6A==",
+      "version": "13.15.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.15.0.tgz",
+      "integrity": "sha512-bpzcOlgDhMG070Av0Vy5Owklpv1I6+j96GhUI7Rh7IzDCKLzboflLrrfqMu8NquDbiR4EOQk7XzJwqVJxicxog==",
       "dependencies": {
         "type-fest": "^0.20.2"
       },
@@ -3725,15 +3738,15 @@
       }
     },
     "node_modules/@parcel/packager-raw": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@parcel/packager-raw/-/packager-raw-2.4.1.tgz",
-      "integrity": "sha512-4lCY3TjiYaZyRIqshNF21i6XkQ5PJyr+ahhK4O2IymuYuD8/wGH2amTZqKPpGLuiF3j1HskRRUNv1ekpvExJ8w==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/packager-raw/-/packager-raw-2.6.0.tgz",
+      "integrity": "sha512-ktT6Qc/GgCq8H1+6y+AXufVzQj1s6KRoKf83qswCD0iY3MwCbJoEfc3IsB4K64FpHIL5Eu0z54IId+INvGbOYA==",
       "dependencies": {
-        "@parcel/plugin": "2.4.1"
+        "@parcel/plugin": "2.6.0"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.4.1"
+        "parcel": "^2.6.0"
       },
       "funding": {
         "type": "opencollective",
@@ -3741,11 +3754,11 @@
       }
     },
     "node_modules/@parcel/plugin": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@parcel/plugin/-/plugin-2.4.1.tgz",
-      "integrity": "sha512-EJzNhwNWYuSpIPRlG1U2hKcovq/RsVie4Os1z51/e2dcCto/uAoJOMoWYYsCxtjkJ7BjFYyQ7fcZRKM9DEr6gQ==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/plugin/-/plugin-2.6.0.tgz",
+      "integrity": "sha512-LzOaiK8R6eFEoov1cb3/W+o0XvXdI/VbDhMDl0L0II+/56M0UeayYtFP5QGTDn/fZqVlYfzPCtt3EMwdG7/dow==",
       "dependencies": {
-        "@parcel/types": "2.4.1"
+        "@parcel/types": "2.6.0"
       },
       "engines": {
         "node": ">= 12.0.0"
@@ -3756,16 +3769,16 @@
       }
     },
     "node_modules/@parcel/reporter-dev-server": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@parcel/reporter-dev-server/-/reporter-dev-server-2.4.1.tgz",
-      "integrity": "sha512-tRz1LHiudDhujBC3kJ3Qm0Wnbo3p3SpE6fjyCFRhdv2PJnEufNTTwzEUoa7lYZACwFVQUtrh6F7nMXFw6ynrsQ==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/reporter-dev-server/-/reporter-dev-server-2.6.0.tgz",
+      "integrity": "sha512-VvygsCA+uzWyijIV8zqU1gFyhAWknuaY4KIWhV4kCT8afRJwsLSwt/tpdaKDPuPU45h3tTsUdXH1wjaIk+dGeQ==",
       "dependencies": {
-        "@parcel/plugin": "2.4.1",
-        "@parcel/utils": "2.4.1"
+        "@parcel/plugin": "2.6.0",
+        "@parcel/utils": "2.6.0"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.4.1"
+        "parcel": "^2.6.0"
       },
       "funding": {
         "type": "opencollective",
@@ -3773,16 +3786,16 @@
       }
     },
     "node_modules/@parcel/resolver-default": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@parcel/resolver-default/-/resolver-default-2.4.1.tgz",
-      "integrity": "sha512-iJRt1+7lk0n7+wb+S/tVyiObbaiYP1YQGKRsTE8y4Kgp4/OPukdUHGFJwzbojWa0HnyoXm3zEgelVz7cHl47fQ==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/resolver-default/-/resolver-default-2.6.0.tgz",
+      "integrity": "sha512-ATk9wXvy5GOHAqyHbnCnU11fUPTtf8dLjpgVqL5XylwugZnyBXbynoTWX4w8h6mffkVtdfmzTJx/o4Lresz9sA==",
       "dependencies": {
-        "@parcel/node-resolver-core": "2.4.1",
-        "@parcel/plugin": "2.4.1"
+        "@parcel/node-resolver-core": "2.6.0",
+        "@parcel/plugin": "2.6.0"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.4.1"
+        "parcel": "^2.6.0"
       },
       "funding": {
         "type": "opencollective",
@@ -3790,16 +3803,16 @@
       }
     },
     "node_modules/@parcel/runtime-browser-hmr": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@parcel/runtime-browser-hmr/-/runtime-browser-hmr-2.4.1.tgz",
-      "integrity": "sha512-INsr78Kn0OuwMdXHCzw7v6l3Gf/UBTYtX7N7JNDOIBEFFkuZQiFWyAOI2P/DvMm8qeqcsrKliBO5Xty/a2Ivaw==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/runtime-browser-hmr/-/runtime-browser-hmr-2.6.0.tgz",
+      "integrity": "sha512-90xvv/10cFML5dAhClBEJZ/ExiBQVPqQsZcvRmVZmc5mpZVJMKattWCQrd7pAf7FDYl4JAcvsK3DTwvRT/oLNA==",
       "dependencies": {
-        "@parcel/plugin": "2.4.1",
-        "@parcel/utils": "2.4.1"
+        "@parcel/plugin": "2.6.0",
+        "@parcel/utils": "2.6.0"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.4.1"
+        "parcel": "^2.6.0"
       },
       "funding": {
         "type": "opencollective",
@@ -3807,17 +3820,17 @@
       }
     },
     "node_modules/@parcel/runtime-js": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@parcel/runtime-js/-/runtime-js-2.4.1.tgz",
-      "integrity": "sha512-/EXwRpo+GPvWgN5yD0hjjt84Gm6QWp757dqOOzTG5R2rm1WU+g1a+zJJB1zXkxhu9lleQs44D1jEffzhh2Voyw==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/runtime-js/-/runtime-js-2.6.0.tgz",
+      "integrity": "sha512-R4tJAIT/SX7VBQ+f7WmeekREQzzLsmgP1j486uKhQNyYrpvsN0HnRbg5aqvZjEjkEmSeJR0mOlWtMK5/m+0yTA==",
       "dependencies": {
-        "@parcel/plugin": "2.4.1",
-        "@parcel/utils": "2.4.1",
+        "@parcel/plugin": "2.6.0",
+        "@parcel/utils": "2.6.0",
         "nullthrows": "^1.1.1"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.4.1"
+        "parcel": "^2.6.0"
       },
       "funding": {
         "type": "opencollective",
@@ -3825,35 +3838,41 @@
       }
     },
     "node_modules/@parcel/runtime-react-refresh": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@parcel/runtime-react-refresh/-/runtime-react-refresh-2.4.1.tgz",
-      "integrity": "sha512-a4GBQ/fO7Mklh1M1G2JVpJBPbZD7YXUPAzh9Y4vpCf0ouTHBRMc8ew4CyKPJIrrTly5P42tFWnD3P4FVNKwHOQ==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/runtime-react-refresh/-/runtime-react-refresh-2.6.0.tgz",
+      "integrity": "sha512-2sRd13gc2EbMV/O5n2NPVGGhKBasb1fDTXGEY8y7qi9xDKc+ewok/D83T+w243FhCPS9Pf3ur5GkbPlrJGcenQ==",
       "dependencies": {
-        "@parcel/plugin": "2.4.1",
-        "@parcel/utils": "2.4.1",
+        "@parcel/plugin": "2.6.0",
+        "@parcel/utils": "2.6.0",
+        "react-error-overlay": "6.0.9",
         "react-refresh": "^0.9.0"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.4.1"
+        "parcel": "^2.6.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/@parcel/runtime-react-refresh/node_modules/react-error-overlay": {
+      "version": "6.0.9",
+      "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.9.tgz",
+      "integrity": "sha512-nQTTcUu+ATDbrSD1BZHr5kgSD4oF8OFjxun8uAaL8RwPBacGBNPf/yAuVVdx17N8XNzRDMrZ9XcKZHCjPW+9ew=="
+    },
     "node_modules/@parcel/runtime-service-worker": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@parcel/runtime-service-worker/-/runtime-service-worker-2.4.1.tgz",
-      "integrity": "sha512-WtMKSiyQ0kF78rBw0XIx7n65mMb+6GBx+5m49r1aVZzeZEOSynpjJzJvqo7rxVmA7qTDkD2bko7BH41iScsEaw==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/runtime-service-worker/-/runtime-service-worker-2.6.0.tgz",
+      "integrity": "sha512-nVlknGw5J5Bkd1Wr1TbyWHhUd9CmVVebaRg/lpfVKYhAuE/2r+3N0+J8qbEIgtTRcHaSV7wTNpg4weSWq46VeA==",
       "dependencies": {
-        "@parcel/plugin": "2.4.1",
-        "@parcel/utils": "2.4.1",
+        "@parcel/plugin": "2.6.0",
+        "@parcel/utils": "2.6.0",
         "nullthrows": "^1.1.1"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.4.1"
+        "parcel": "^2.6.0"
       },
       "funding": {
         "type": "opencollective",
@@ -3861,9 +3880,9 @@
       }
     },
     "node_modules/@parcel/source-map": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@parcel/source-map/-/source-map-2.0.2.tgz",
-      "integrity": "sha512-NnUrPYLpYB6qyx2v6bcRPn/gVigmGG6M6xL8wIg/i0dP1GLkuY1nf+Hqdf63FzPTqqT7K3k6eE5yHPQVMO5jcA==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@parcel/source-map/-/source-map-2.0.5.tgz",
+      "integrity": "sha512-DRVlCFKLpqBSIbMxUoVlHgfiv12HTW/U7nnhzw52YgzDVXUX9OA41dXS1PU0pJ1si+D1k8msATUC+AoldN43mg==",
       "dependencies": {
         "detect-libc": "^1.0.3"
       },
@@ -3872,16 +3891,16 @@
       }
     },
     "node_modules/@parcel/transformer-js": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-js/-/transformer-js-2.4.1.tgz",
-      "integrity": "sha512-39Y9RUuDk5dc09Z3Pgj8snQd5E8926IqOowdTLKNJr7EcmkwHdinbpI4EqgKnisOwX4NSzxUti1I2DHsP1QZHw==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-js/-/transformer-js-2.6.0.tgz",
+      "integrity": "sha512-4v2r3EVdMKowBziVBW9HZqvAv88HaeiezkWyMX4wAfplo9jBtWEp99KEQINzSEdbXROR81M9oJjlGF5+yoVr/w==",
       "dependencies": {
-        "@parcel/diagnostic": "2.4.1",
-        "@parcel/plugin": "2.4.1",
+        "@parcel/diagnostic": "2.6.0",
+        "@parcel/plugin": "2.6.0",
         "@parcel/source-map": "^2.0.0",
-        "@parcel/utils": "2.4.1",
-        "@parcel/workers": "2.4.1",
-        "@swc/helpers": "^0.3.6",
+        "@parcel/utils": "2.6.0",
+        "@parcel/workers": "2.6.0",
+        "@swc/helpers": "^0.3.15",
         "browserslist": "^4.6.6",
         "detect-libc": "^1.0.3",
         "nullthrows": "^1.1.1",
@@ -3890,11 +3909,14 @@
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.4.1"
+        "parcel": "^2.6.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
+      },
+      "peerDependencies": {
+        "@parcel/core": "^2.6.0"
       }
     },
     "node_modules/@parcel/transformer-js/node_modules/semver": {
@@ -3906,16 +3928,16 @@
       }
     },
     "node_modules/@parcel/transformer-json": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-json/-/transformer-json-2.4.1.tgz",
-      "integrity": "sha512-bAwKyWb2/Wm6GS7OpQg1lWgcq+VDBXTKy5oFGX3edbpZFsrb59Ln1v+1jI888zRq4ehDBybhx8WTxPKTJnU+jA==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-json/-/transformer-json-2.6.0.tgz",
+      "integrity": "sha512-zb+TQAdHWdXijKcFhLe+5KN1O0IzXwW1gJhPr8DJEA3qhPaCsncsw5RCVjQlP3a7NXr1mMm1eMtO6bhIMqbXeA==",
       "dependencies": {
-        "@parcel/plugin": "2.4.1",
+        "@parcel/plugin": "2.6.0",
         "json5": "^2.2.0"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.4.1"
+        "parcel": "^2.6.0"
       },
       "funding": {
         "type": "opencollective",
@@ -3923,15 +3945,15 @@
       }
     },
     "node_modules/@parcel/transformer-raw": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-raw/-/transformer-raw-2.4.1.tgz",
-      "integrity": "sha512-0PzdWJSGSTQ522aohymHEnq4GABy0mHSs+LkPZyMfNmX9ZAIyy6XuFJ9dz8nUmP4Nhn8qDvbRjoAYXR3XsGDGQ==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-raw/-/transformer-raw-2.6.0.tgz",
+      "integrity": "sha512-QDirlWCS/qy0DQ3WvDIAnFP52n1TJW/uWH+4PGMNnX4/M3/2UchY8xp9CN0tx4NQ4g09S8o3gLlHvNxQqZxFrQ==",
       "dependencies": {
-        "@parcel/plugin": "2.4.1"
+        "@parcel/plugin": "2.6.0"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.4.1"
+        "parcel": "^2.6.0"
       },
       "funding": {
         "type": "opencollective",
@@ -3939,17 +3961,17 @@
       }
     },
     "node_modules/@parcel/transformer-react-refresh-wrap": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-react-refresh-wrap/-/transformer-react-refresh-wrap-2.4.1.tgz",
-      "integrity": "sha512-zF6pzj/BwSiD1jA/BHDCEJnKSIDekjblU+OWp1WpSjA1uYkJORuZ5knLcq6mXOQ8M2NCbOXosc1ru8071i8sYA==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-react-refresh-wrap/-/transformer-react-refresh-wrap-2.6.0.tgz",
+      "integrity": "sha512-G34orfvLDUTumuerqNmA8T8NUHk+R0jwUjbVPO7gpB6VCVQ5ocTABdE9vN9Uu/cUsHij40TUFwqK4R9TFEBIEQ==",
       "dependencies": {
-        "@parcel/plugin": "2.4.1",
-        "@parcel/utils": "2.4.1",
+        "@parcel/plugin": "2.6.0",
+        "@parcel/utils": "2.6.0",
         "react-refresh": "^0.9.0"
       },
       "engines": {
         "node": ">= 12.0.0",
-        "parcel": "^2.4.1"
+        "parcel": "^2.6.0"
       },
       "funding": {
         "type": "opencollective",
@@ -3957,29 +3979,29 @@
       }
     },
     "node_modules/@parcel/types": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@parcel/types/-/types-2.4.1.tgz",
-      "integrity": "sha512-YqkiyGS8oiD89Z2lJP7sbjn0F0wlSJMAuqgqf7obeKj0zmZJS7n2xK0uUEuIlUO+Cbqgl0kCGsUSjuT8xcEqjg==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/types/-/types-2.6.0.tgz",
+      "integrity": "sha512-lAMYvOBfNEJMsPJ+plbB50305o0TwNrY1xX5RRIWBqwOa6bYmbW1ZljUk1tQvnkpIE4eAHQwnPR5Z2XWg18wGQ==",
       "dependencies": {
-        "@parcel/cache": "2.4.1",
-        "@parcel/diagnostic": "2.4.1",
-        "@parcel/fs": "2.4.1",
-        "@parcel/package-manager": "2.4.1",
+        "@parcel/cache": "2.6.0",
+        "@parcel/diagnostic": "2.6.0",
+        "@parcel/fs": "2.6.0",
+        "@parcel/package-manager": "2.6.0",
         "@parcel/source-map": "^2.0.0",
-        "@parcel/workers": "2.4.1",
+        "@parcel/workers": "2.6.0",
         "utility-types": "^3.10.0"
       }
     },
     "node_modules/@parcel/utils": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.4.1.tgz",
-      "integrity": "sha512-hmbrnPtFAfMT6s9FMMIVlIzCwEFX/+byB67GoJmSCAMRmj6RMu4a6xKlv2FdzkTKJV2ucg8vxAcua0MQ/q8rkQ==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.6.0.tgz",
+      "integrity": "sha512-ElXz+QHtT1JQIucbQJBk7SzAGoOlBp4yodEQVvTKS7GA+hEGrSP/cmibl6qm29Rjtd0zgQsdd+2XmP3xvP2gQQ==",
       "dependencies": {
-        "@parcel/codeframe": "2.4.1",
-        "@parcel/diagnostic": "2.4.1",
-        "@parcel/hash": "2.4.1",
-        "@parcel/logger": "2.4.1",
-        "@parcel/markdown-ansi": "2.4.1",
+        "@parcel/codeframe": "2.6.0",
+        "@parcel/diagnostic": "2.6.0",
+        "@parcel/hash": "2.6.0",
+        "@parcel/logger": "2.6.0",
+        "@parcel/markdown-ansi": "2.6.0",
         "@parcel/source-map": "^2.0.0",
         "chalk": "^4.1.0"
       },
@@ -4073,14 +4095,14 @@
       }
     },
     "node_modules/@parcel/workers": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@parcel/workers/-/workers-2.4.1.tgz",
-      "integrity": "sha512-EYujbJOblFqIt2NGQ+baIYTuavJqbhy84IfZ3j0jmACeKO5Ew1EHXZyl9LJgWHKaIPZsnvnbxw2mDOF05K65xQ==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/workers/-/workers-2.6.0.tgz",
+      "integrity": "sha512-3tcI2LF5fd/WZtSnSjyWdDE+G+FitdNrRgSObzSp+axHKMAM23sO0z7KY8s2SYCF40msdYbFUW8eI6JlYNJoWQ==",
       "dependencies": {
-        "@parcel/diagnostic": "2.4.1",
-        "@parcel/logger": "2.4.1",
-        "@parcel/types": "2.4.1",
-        "@parcel/utils": "2.4.1",
+        "@parcel/diagnostic": "2.6.0",
+        "@parcel/logger": "2.6.0",
+        "@parcel/types": "2.6.0",
+        "@parcel/utils": "2.6.0",
         "chrome-trace-event": "^1.0.2",
         "nullthrows": "^1.1.1"
       },
@@ -4092,7 +4114,7 @@
         "url": "https://opencollective.com/parcel"
       },
       "peerDependencies": {
-        "@parcel/core": "^2.4.1"
+        "@parcel/core": "^2.6.0"
       }
     },
     "node_modules/@pmmmwh/react-refresh-webpack-plugin": {
@@ -4239,9 +4261,17 @@
       }
     },
     "node_modules/@swc/helpers": {
-      "version": "0.3.8",
-      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.3.8.tgz",
-      "integrity": "sha512-aWItSZvJj4+GI6FWkjZR13xPNPctq2RRakzo+O6vN7bC2yjwdg5EFpgaSAUn95b7BGSgcflvzVDPoKmJv24IOg=="
+      "version": "0.3.17",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.3.17.tgz",
+      "integrity": "sha512-tb7Iu+oZ+zWJZ3HJqwx8oNwSDIU440hmVMDPhpACWQWnrZHK99Bxs70gT1L2dnr5Hg50ZRWEFkQCAnOVVV0z1Q==",
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@swc/helpers/node_modules/tslib": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
     },
     "node_modules/@szmarczak/http-timer": {
       "version": "4.0.6",
@@ -5158,7 +5188,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
       "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
-      "dev": true,
       "dependencies": {
         "clean-stack": "^2.0.0",
         "indent-string": "^4.0.0"
@@ -6760,7 +6789,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
       "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
-      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -7032,7 +7060,7 @@
     "node_modules/clone": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
-      "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=",
+      "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==",
       "engines": {
         "node": ">=0.8"
       }
@@ -8076,6 +8104,62 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/del": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/del/-/del-5.1.0.tgz",
+      "integrity": "sha512-wH9xOVHnczo9jN2IW68BabcecVPxacIA3g/7z6vhSU/4stOKQzeCRK0yD0A24WiAAUJmmVpWqrERcTxnLo3AnA==",
+      "dependencies": {
+        "globby": "^10.0.1",
+        "graceful-fs": "^4.2.2",
+        "is-glob": "^4.0.1",
+        "is-path-cwd": "^2.2.0",
+        "is-path-inside": "^3.0.1",
+        "p-map": "^3.0.0",
+        "rimraf": "^3.0.0",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/del/node_modules/@types/glob": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.2.0.tgz",
+      "integrity": "sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==",
+      "dependencies": {
+        "@types/minimatch": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/del/node_modules/globby": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-10.0.2.tgz",
+      "integrity": "sha512-7dUi7RvCoT/xast/o/dLN53oqND4yk0nsHkhRgn9w65C4PofCLOoJ39iSOg+qVDdWQPIEj+eszMHQ+aLVwwQSg==",
+      "dependencies": {
+        "@types/glob": "^7.1.1",
+        "array-union": "^2.1.0",
+        "dir-glob": "^3.0.1",
+        "fast-glob": "^3.0.3",
+        "glob": "^7.1.3",
+        "ignore": "^5.1.1",
+        "merge2": "^1.2.3",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/del/node_modules/p-map": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-3.0.0.tgz",
+      "integrity": "sha512-d3qXVTF/s+W+CdJ5A29wywV2n8CQQYahlgz2bFiA+4eVNJbHJodPZ+/gXwPGh0bOqA+j8S+6+ckmvLGPk1QpxQ==",
+      "dependencies": {
+        "aggregate-error": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -8121,7 +8205,7 @@
     "node_modules/detect-libc": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
-      "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
+      "integrity": "sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==",
       "bin": {
         "detect-libc": "bin/detect-libc.js"
       },
@@ -10400,9 +10484,9 @@
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc="
     },
     "node_modules/gatsby": {
-      "version": "4.11.3",
-      "resolved": "https://registry.npmjs.org/gatsby/-/gatsby-4.11.3.tgz",
-      "integrity": "sha512-NmdWedBvIgeJqR1klE16QvuJjyshqQBU2FiZBWlt3foJ7syXoF6Ab7Eb5JafWsm89ejZyePiI79aHSDraIuZQA==",
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/gatsby/-/gatsby-4.9.0.tgz",
+      "integrity": "sha512-wDCzcCx4hKMqldwuXoG8gQq2nkL7zSqoJXEqWK4nKp8PJKi5DgJxBteKMWOoLPYsaqGZ0ccZmYvp76/zjl2olQ==",
       "hasInstallScript": true,
       "dependencies": {
         "@babel/code-frame": "^7.14.0",
@@ -10416,7 +10500,7 @@
         "@gatsbyjs/reach-router": "^1.3.6",
         "@gatsbyjs/webpack-hot-middleware": "^2.25.2",
         "@nodelib/fs.walk": "^1.2.8",
-        "@parcel/core": "^2.3.2",
+        "@parcel/core": "^2.3.1",
         "@pmmmwh/react-refresh-webpack-plugin": "^0.4.3",
         "@types/http-proxy": "^1.17.7",
         "@typescript-eslint/eslint-plugin": "^4.33.0",
@@ -10430,8 +10514,8 @@
         "babel-plugin-add-module-exports": "^1.0.4",
         "babel-plugin-dynamic-import-node": "^2.3.3",
         "babel-plugin-lodash": "^3.3.4",
-        "babel-plugin-remove-graphql-queries": "^4.11.1",
-        "babel-preset-gatsby": "^2.11.1",
+        "babel-plugin-remove-graphql-queries": "^4.9.0",
+        "babel-preset-gatsby": "^2.9.0",
         "better-opn": "^2.1.1",
         "bluebird": "^3.7.2",
         "body-parser": "^1.19.0",
@@ -10450,6 +10534,7 @@
         "date-fns": "^2.25.0",
         "debug": "^3.2.7",
         "deepmerge": "^4.2.2",
+        "del": "^5.1.0",
         "detect-port": "^1.3.0",
         "devcert": "^1.2.0",
         "dotenv": "^8.6.0",
@@ -10473,21 +10558,20 @@
         "find-cache-dir": "^3.3.2",
         "fs-exists-cached": "1.0.0",
         "fs-extra": "^10.0.0",
-        "gatsby-cli": "^4.11.2",
-        "gatsby-core-utils": "^3.11.1",
-        "gatsby-graphiql-explorer": "^2.11.0",
-        "gatsby-legacy-polyfills": "^2.11.0",
-        "gatsby-link": "^4.11.1",
-        "gatsby-page-utils": "^2.11.1",
-        "gatsby-parcel-config": "^0.2.0",
-        "gatsby-plugin-page-creator": "^4.11.1",
-        "gatsby-plugin-typescript": "^4.11.1",
-        "gatsby-plugin-utils": "^3.5.1",
-        "gatsby-react-router-scroll": "^5.11.0",
-        "gatsby-telemetry": "^3.11.1",
-        "gatsby-worker": "^1.11.0",
+        "gatsby-cli": "^4.9.0",
+        "gatsby-core-utils": "^3.9.0",
+        "gatsby-graphiql-explorer": "^2.9.0",
+        "gatsby-legacy-polyfills": "^2.9.0",
+        "gatsby-link": "^4.9.0",
+        "gatsby-page-utils": "^2.9.0",
+        "gatsby-parcel-config": "^0.0.1",
+        "gatsby-plugin-page-creator": "^4.9.0",
+        "gatsby-plugin-typescript": "^4.9.0",
+        "gatsby-plugin-utils": "^3.3.0",
+        "gatsby-react-router-scroll": "^5.9.0",
+        "gatsby-telemetry": "^3.9.0",
+        "gatsby-worker": "^1.9.0",
         "glob": "^7.2.0",
-        "globby": "^11.1.0",
         "got": "^11.8.2",
         "graphql": "^15.7.2",
         "graphql-compose": "^9.0.7",
@@ -10500,7 +10584,7 @@
         "joi": "^17.4.2",
         "json-loader": "^0.5.7",
         "latest-version": "5.1.0",
-        "lmdb": "~2.2.3",
+        "lmdb": "2.2.1",
         "lodash": "^4.17.21",
         "md5-file": "^5.0.0",
         "meant": "^1.0.3",
@@ -10565,11 +10649,11 @@
         "node": ">=14.15.0"
       },
       "optionalDependencies": {
-        "gatsby-sharp": "^0.5.0"
+        "gatsby-sharp": "^0.3.0"
       },
       "peerDependencies": {
-        "react": "^16.9.0 || ^17.0.0 || ^18.0.0",
-        "react-dom": "^16.9.0 || ^17.0.0 || ^18.0.0"
+        "react": "^16.9.0 || ^17.0.0",
+        "react-dom": "^16.9.0 || ^17.0.0"
       }
     },
     "node_modules/gatsby-cli": {
@@ -10838,27 +10922,27 @@
       }
     },
     "node_modules/gatsby-parcel-config": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/gatsby-parcel-config/-/gatsby-parcel-config-0.2.0.tgz",
-      "integrity": "sha512-BbsSm5O0R7IvCRLNSk3lBpkU8RtSOn8s7Ifa7bHF63PzTG1SUpBjwMF6301tCbvdSXWrP7n9dsfaXS6ex/TElQ==",
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/gatsby-parcel-config/-/gatsby-parcel-config-0.0.1.tgz",
+      "integrity": "sha512-HYmIVyGLc9J0ZsJDiz6/PpfBSvl1mIPzQiWaGnou1R6KjGxoIlyp7kFCj4yuBlQXecjQ+gG3BY/osBi7FPY1qw==",
       "dependencies": {
         "@gatsbyjs/parcel-namer-relative-to-cwd": "0.0.2",
-        "@parcel/bundler-default": "^2.3.2",
-        "@parcel/compressor-raw": "^2.3.2",
-        "@parcel/namer-default": "^2.3.2",
-        "@parcel/optimizer-terser": "^2.3.2",
-        "@parcel/packager-js": "^2.3.2",
-        "@parcel/packager-raw": "^2.3.2",
-        "@parcel/reporter-dev-server": "^2.3.2",
-        "@parcel/resolver-default": "^2.3.2",
-        "@parcel/runtime-browser-hmr": "^2.3.2",
-        "@parcel/runtime-js": "^2.3.2",
-        "@parcel/runtime-react-refresh": "^2.3.2",
-        "@parcel/runtime-service-worker": "^2.3.2",
-        "@parcel/transformer-js": "^2.3.2",
-        "@parcel/transformer-json": "^2.3.2",
-        "@parcel/transformer-raw": "^2.3.2",
-        "@parcel/transformer-react-refresh-wrap": "^2.3.2"
+        "@parcel/bundler-default": "^2.3.1",
+        "@parcel/compressor-raw": "^2.3.1",
+        "@parcel/namer-default": "^2.3.1",
+        "@parcel/optimizer-terser": "^2.3.1",
+        "@parcel/packager-js": "^2.3.1",
+        "@parcel/packager-raw": "^2.3.1",
+        "@parcel/reporter-dev-server": "^2.3.1",
+        "@parcel/resolver-default": "^2.3.1",
+        "@parcel/runtime-browser-hmr": "^2.3.1",
+        "@parcel/runtime-js": "^2.3.1",
+        "@parcel/runtime-react-refresh": "^2.3.1",
+        "@parcel/runtime-service-worker": "^2.3.1",
+        "@parcel/transformer-js": "^2.3.1",
+        "@parcel/transformer-json": "^2.3.1",
+        "@parcel/transformer-raw": "^2.3.1",
+        "@parcel/transformer-react-refresh-wrap": "^2.3.1"
       },
       "engines": {
         "parcel": "2.x"
@@ -12482,6 +12566,19 @@
         "node": ">=4"
       }
     },
+    "node_modules/gatsby/node_modules/gatsby-sharp": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/gatsby-sharp/-/gatsby-sharp-0.3.0.tgz",
+      "integrity": "sha512-lMrmtoJjpCGoxnZbaQjfcF6vARPWgONw9r8fqGkHag0iSfcGpj3IM+LRdXT/i1mhNPDeB6pKBm5CvY8sYIgD0A==",
+      "optional": true,
+      "dependencies": {
+        "@types/sharp": "^0.29.5",
+        "sharp": "^0.30.1"
+      },
+      "engines": {
+        "node": ">=14.15.0"
+      }
+    },
     "node_modules/gatsby/node_modules/glob-parent": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
@@ -12525,6 +12622,19 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/gatsby/node_modules/lmdb": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/lmdb/-/lmdb-2.2.1.tgz",
+      "integrity": "sha512-tUlIjyJvbd4mqdotI9Xe+3PZt/jqPx70VKFDrKMYu09MtBWOT3y2PbuTajX+bJFDjbgLkQC0cTx2n6dithp/zQ==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "msgpackr": "^1.5.4",
+        "nan": "^2.14.2",
+        "node-gyp-build": "^4.2.3",
+        "ordered-binary": "^1.2.4",
+        "weak-lru-cache": "^1.2.2"
       }
     },
     "node_modules/gatsby/node_modules/lru-cache": {
@@ -14173,6 +14283,14 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-path-cwd": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-2.2.0.tgz",
+      "integrity": "sha512-w942bTcih8fdJPJmQHFzkS76NEP8Kzzvmw92cXsazb8intwLqPibPPdXf4ANdKV3rYMuuQYGIWtvz9JilB3NFQ==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/is-path-inside": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
@@ -14824,17 +14942,103 @@
       }
     },
     "node_modules/lmdb": {
-      "version": "2.2.6",
-      "resolved": "https://registry.npmjs.org/lmdb/-/lmdb-2.2.6.tgz",
-      "integrity": "sha512-UmQV0oZZcV3EN6rjcAjIiuWcc3MYZGWQ0GUYz46Ron5fuTa/dUow7WSQa6leFkvZIKVUdECBWVw96tckfEzUFQ==",
+      "version": "2.3.10",
+      "resolved": "https://registry.npmjs.org/lmdb/-/lmdb-2.3.10.tgz",
+      "integrity": "sha512-GtH+nStn9V59CfYeQ5ddx6YTfuFCmu86UJojIjJAweG+/Fm0PDknuk3ovgYDtY/foMeMdZa8/P7oSljW/d5UPw==",
       "hasInstallScript": true,
       "dependencies": {
         "msgpackr": "^1.5.4",
         "nan": "^2.14.2",
-        "node-gyp-build": "^4.2.3",
+        "node-addon-api": "^4.3.0",
+        "node-gyp-build-optional-packages": "^4.3.2",
         "ordered-binary": "^1.2.4",
         "weak-lru-cache": "^1.2.2"
+      },
+      "optionalDependencies": {
+        "lmdb-darwin-arm64": "2.3.10",
+        "lmdb-darwin-x64": "2.3.10",
+        "lmdb-linux-arm": "2.3.10",
+        "lmdb-linux-arm64": "2.3.10",
+        "lmdb-linux-x64": "2.3.10",
+        "lmdb-win32-x64": "2.3.10"
       }
+    },
+    "node_modules/lmdb-darwin-arm64": {
+      "version": "2.3.10",
+      "resolved": "https://registry.npmjs.org/lmdb-darwin-arm64/-/lmdb-darwin-arm64-2.3.10.tgz",
+      "integrity": "sha512-LVXbH2MYu7/ZuQ8+P9rv+SwNyBKltxo7vHAGJS94HWyfwnCbKEYER9PImBvNBwzvgtaYk6x0RMX3oor6e6KdDQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/lmdb-darwin-x64": {
+      "version": "2.3.10",
+      "resolved": "https://registry.npmjs.org/lmdb-darwin-x64/-/lmdb-darwin-x64-2.3.10.tgz",
+      "integrity": "sha512-gAc/1b/FZOb9yVOT+o0huA+hdW82oxLo5r22dFTLoRUFG1JMzxdTjmnW6ONVOHdqC9a5bt3vBCEY3jmXNqV26A==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/lmdb-linux-arm": {
+      "version": "2.3.10",
+      "resolved": "https://registry.npmjs.org/lmdb-linux-arm/-/lmdb-linux-arm-2.3.10.tgz",
+      "integrity": "sha512-Rb8+4JjsThuEcJ7GLLwFkCFnoiwv/3hAAbELWITz70buQFF+dCZvCWWgEgmDTxwn5r+wIkdUjmFv4dqqiKQFmQ==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/lmdb-linux-arm64": {
+      "version": "2.3.10",
+      "resolved": "https://registry.npmjs.org/lmdb-linux-arm64/-/lmdb-linux-arm64-2.3.10.tgz",
+      "integrity": "sha512-Ihr8mdICTK3jA4GXHxrXGK2oekn0mY6zuDSXQDNtyRSH19j3D2Y04A7SEI9S0EP/t5sjKSudYgZbiHDxRCsI5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/lmdb-linux-x64": {
+      "version": "2.3.10",
+      "resolved": "https://registry.npmjs.org/lmdb-linux-x64/-/lmdb-linux-x64-2.3.10.tgz",
+      "integrity": "sha512-E3l3pDiCA9uvnLf+t3qkmBGRO01dp1EHD0x0g0iRnfpAhV7wYbayJGfG93BUt22Tj3fnq4HDo4dQ6ZWaDI1nuw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/lmdb-win32-x64": {
+      "version": "2.3.10",
+      "resolved": "https://registry.npmjs.org/lmdb-win32-x64/-/lmdb-win32-x64-2.3.10.tgz",
+      "integrity": "sha512-gspWk34tDANhjn+brdqZstJMptGiwj4qFNVg0Zey9ds+BUlif+Lgf5szrfOVzZ8gVRkk1Lgbz7i78+V7YK7SCA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/lmdb/node_modules/node-addon-api": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-4.3.0.tgz",
+      "integrity": "sha512-73sE9+3UaLYYFmDsFZnqCInzPyh3MqIwZO9cw58yIqAZhONrrabrYyYe3TuIqtIiOuTXVhsGau8hcrhhwSsDIQ=="
     },
     "node_modules/load-bmfont": {
       "version": "1.4.1",
@@ -16130,7 +16334,6 @@
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/node-gyp-build-optional-packages/-/node-gyp-build-optional-packages-4.3.2.tgz",
       "integrity": "sha512-P5Ep3ISdmwcCkZIaBaQamQtWAG0facC89phWZgi5Z3hBU//J6S48OIvyZWSPPf6yQMklLZiqoosWAZUj7N+esA==",
-      "optional": true,
       "bin": {
         "node-gyp-build-optional": "optional.js",
         "node-gyp-build-optional-packages": "bin.js",
@@ -25758,6 +25961,19 @@
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
+    "@lezer/common": {
+      "version": "0.15.12",
+      "resolved": "https://registry.npmjs.org/@lezer/common/-/common-0.15.12.tgz",
+      "integrity": "sha512-edfwCxNLnzq5pBA/yaIhwJ3U3Kz8VAUOTRg0hhxaizaI1N+qxV7EXDv/kLCkLeq2RzSFvxexlaj5Mzfn2kY0Ig=="
+    },
+    "@lezer/lr": {
+      "version": "0.15.8",
+      "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-0.15.8.tgz",
+      "integrity": "sha512-bM6oE6VQZ6hIFxDNKk8bKPa14hqFrV07J/vHGOeiAbJReIaQXmkVb6xQu4MR+JBTLa5arGRyAAjJe1qaQt3Uvg==",
+      "requires": {
+        "@lezer/common": "^0.15.0"
+      }
+    },
     "@mdx-js/mdx": {
       "version": "1.6.22",
       "resolved": "https://registry.npmjs.org/@mdx-js/mdx/-/mdx-1.6.22.tgz",
@@ -25830,6 +26046,16 @@
       "resolved": "https://registry.npmjs.org/@microsoft/fetch-event-source/-/fetch-event-source-2.0.1.tgz",
       "integrity": "sha512-W6CLUJ2eBMw3Rec70qrsEW0jOm/3twwJv21mrmj2yORiaVmVYGS4sSS5yUwvQc1ZlDLYGPnClVWmUUMagKNsfA=="
     },
+    "@mischnic/json-sourcemap": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@mischnic/json-sourcemap/-/json-sourcemap-0.1.0.tgz",
+      "integrity": "sha512-dQb3QnfNqmQNYA4nFSN/uLaByIic58gOXq4Y4XqLOWmOrw73KmJPt/HLyG0wvn1bnR6mBKs/Uwvkh+Hns1T0XA==",
+      "requires": {
+        "@lezer/common": "^0.15.7",
+        "@lezer/lr": "^0.15.4",
+        "json5": "^2.2.1"
+      }
+    },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -25854,46 +26080,32 @@
       }
     },
     "@parcel/bundler-default": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@parcel/bundler-default/-/bundler-default-2.4.1.tgz",
-      "integrity": "sha512-PTfBOuoiiYdfwyoPFeBTOinyl1RL4qaoyAQ0PCe01C1i4NcRWCY1w7zRvwJW/OhU3Ka+LtioGmfxu5/drdXzLg==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/bundler-default/-/bundler-default-2.6.0.tgz",
+      "integrity": "sha512-AplEdGm/odV7yGmoeOnglxnY31WlNB5EqGLFGxkgs7uwDaTWoTX/9SWPG6xfvirhjDpms8sLSiVuBdFRCCLtNA==",
       "requires": {
-        "@parcel/diagnostic": "2.4.1",
-        "@parcel/hash": "2.4.1",
-        "@parcel/plugin": "2.4.1",
-        "@parcel/utils": "2.4.1",
+        "@parcel/diagnostic": "2.6.0",
+        "@parcel/hash": "2.6.0",
+        "@parcel/plugin": "2.6.0",
+        "@parcel/utils": "2.6.0",
         "nullthrows": "^1.1.1"
       }
     },
     "@parcel/cache": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@parcel/cache/-/cache-2.4.1.tgz",
-      "integrity": "sha512-2N5ly++p/yefmPdK39X1QIoA2e6NtS1aYSsxrIC9EX92Kjd7SfSceqUJhlJWB49omJSheEJLd1qM3EJG9EvICQ==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/cache/-/cache-2.6.0.tgz",
+      "integrity": "sha512-4vbD5uSuf+kRnrFesKhpn0AKnOw8u2UlvCyrplYmp1g9bNAkIooC/nDGdmkb/9SviPEbni9PEanQEHDU2+slpA==",
       "requires": {
-        "@parcel/fs": "2.4.1",
-        "@parcel/logger": "2.4.1",
-        "@parcel/utils": "2.4.1",
-        "lmdb": "2.2.4"
-      },
-      "dependencies": {
-        "lmdb": {
-          "version": "2.2.4",
-          "resolved": "https://registry.npmjs.org/lmdb/-/lmdb-2.2.4.tgz",
-          "integrity": "sha512-gto+BB2uEob8qRiTlOq+R3uX0YNHsX9mjxj9Sbdue/LIKqu6IlZjrsjKeGyOMquc/474GEqFyX2pdytpydp0rQ==",
-          "requires": {
-            "msgpackr": "^1.5.4",
-            "nan": "^2.14.2",
-            "node-gyp-build": "^4.2.3",
-            "ordered-binary": "^1.2.4",
-            "weak-lru-cache": "^1.2.2"
-          }
-        }
+        "@parcel/fs": "2.6.0",
+        "@parcel/logger": "2.6.0",
+        "@parcel/utils": "2.6.0",
+        "lmdb": "2.3.10"
       }
     },
     "@parcel/codeframe": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@parcel/codeframe/-/codeframe-2.4.1.tgz",
-      "integrity": "sha512-m3WDeEpWvgqekCqsHfPMJrSQquahdIgSR1x1RDCqQ1YelvW0fQiGgu42MXI5tjoBrHC1l1mF01UDb+xMSxz1DA==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/codeframe/-/codeframe-2.6.0.tgz",
+      "integrity": "sha512-yXXxrO9yyedHKpTwC+Af0+vPmQm+A9xeEhkt4f0yVg1n4t4yUIxYlTedzbM8ygZEEBtkXU9jJ+PkgXbfMf0dqw==",
       "requires": {
         "chalk": "^4.1.0"
       },
@@ -25944,38 +26156,38 @@
       }
     },
     "@parcel/compressor-raw": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@parcel/compressor-raw/-/compressor-raw-2.4.1.tgz",
-      "integrity": "sha512-cEOOOzIK7glxCqJX0OfBFBZE/iT7tmjEOXswRY3CnqY9FGoY3NYDAsOLm7A73RuIdNaZfYVxVUy3g7OLpbKL+g==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/compressor-raw/-/compressor-raw-2.6.0.tgz",
+      "integrity": "sha512-rtMU2mGl88bic6Xbq1u5L49bMK4s5185b0k7h3JRdS6/0rR+Xp4k/o9Wog+hHjK/s82z1eF9WmET779ZpIDIQQ==",
       "requires": {
-        "@parcel/plugin": "2.4.1"
+        "@parcel/plugin": "2.6.0"
       }
     },
     "@parcel/core": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@parcel/core/-/core-2.4.1.tgz",
-      "integrity": "sha512-h2FvqLA75ZQdIXX1y+ylGjIIi7YtbAUJyIapxaO081h3EsYG2jr9sRL4sym5ECgmvbyua/DEgtMLX3eGYn09FA==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/core/-/core-2.6.0.tgz",
+      "integrity": "sha512-8OOWbPuxpFydpwNyKoz6d3e3O4DmxNYmMw4DXwrPSj/jyg7oa+SDtMT0/VXEhujE0HYkQPCHt4npRajkSuf99A==",
       "requires": {
-        "@parcel/cache": "2.4.1",
-        "@parcel/diagnostic": "2.4.1",
-        "@parcel/events": "2.4.1",
-        "@parcel/fs": "2.4.1",
-        "@parcel/graph": "2.4.1",
-        "@parcel/hash": "2.4.1",
-        "@parcel/logger": "2.4.1",
-        "@parcel/package-manager": "2.4.1",
-        "@parcel/plugin": "2.4.1",
+        "@mischnic/json-sourcemap": "^0.1.0",
+        "@parcel/cache": "2.6.0",
+        "@parcel/diagnostic": "2.6.0",
+        "@parcel/events": "2.6.0",
+        "@parcel/fs": "2.6.0",
+        "@parcel/graph": "2.6.0",
+        "@parcel/hash": "2.6.0",
+        "@parcel/logger": "2.6.0",
+        "@parcel/package-manager": "2.6.0",
+        "@parcel/plugin": "2.6.0",
         "@parcel/source-map": "^2.0.0",
-        "@parcel/types": "2.4.1",
-        "@parcel/utils": "2.4.1",
-        "@parcel/workers": "2.4.1",
+        "@parcel/types": "2.6.0",
+        "@parcel/utils": "2.6.0",
+        "@parcel/workers": "2.6.0",
         "abortcontroller-polyfill": "^1.1.9",
         "base-x": "^3.0.8",
         "browserslist": "^4.6.6",
         "clone": "^2.1.1",
         "dotenv": "^7.0.0",
         "dotenv-expand": "^5.1.0",
-        "json-source-map": "^0.6.1",
         "json5": "^2.2.0",
         "msgpackr": "^1.5.4",
         "nullthrows": "^1.1.1",
@@ -25995,70 +26207,70 @@
       }
     },
     "@parcel/diagnostic": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@parcel/diagnostic/-/diagnostic-2.4.1.tgz",
-      "integrity": "sha512-wmJIfn0PG2ABuraS+kMjl6UKaLjTDTtG+XkjJLWHzU/dd5RozqAZDKp65GWjvHzHLx7KICTAdUJsXh2s3TnTOQ==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/diagnostic/-/diagnostic-2.6.0.tgz",
+      "integrity": "sha512-+p8gC2FKxSI2veD7SoaNlP572v4kw+nafCQEPDtJuzYYRqywYUGncch25dkpgNApB4W4cXVkZu3ZbtIpCAmjQQ==",
       "requires": {
-        "json-source-map": "^0.6.1",
+        "@mischnic/json-sourcemap": "^0.1.0",
         "nullthrows": "^1.1.1"
       }
     },
     "@parcel/events": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@parcel/events/-/events-2.4.1.tgz",
-      "integrity": "sha512-er2jwyzYt3Zimkrp7TR865GIeIMYNd7YSSxW39y/egm4LIPBsruUpHSnKRD5b65Jd+gckkxDsnrpADG6MH1zNw=="
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/events/-/events-2.6.0.tgz",
+      "integrity": "sha512-2WaKtBs4iYwS88j4zRdyTJTgh8iuY4E32FMmjzzbheqETs6I05gWuPReGukJYxk8vc0Ir7tbzp12oAfpgo0Y+g=="
     },
     "@parcel/fs": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@parcel/fs/-/fs-2.4.1.tgz",
-      "integrity": "sha512-kE9HzW6XjO/ZA5bQnAzp1YVmGlXeDqUaius2cH2K0wU7KQX/GBjyfEWJm/UsKPB6QIrGXgkPH6ashNzOgwDqpw==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/fs/-/fs-2.6.0.tgz",
+      "integrity": "sha512-6vxtx5Zy6MvDvH1EPx9JxjKGF03bR7VE1dUf4HLeX2D8YmpL5hkHJnlRCFdcH08rzOVwaJLzg1QNtblWJXQ9CA==",
       "requires": {
-        "@parcel/fs-search": "2.4.1",
-        "@parcel/types": "2.4.1",
-        "@parcel/utils": "2.4.1",
+        "@parcel/fs-search": "2.6.0",
+        "@parcel/types": "2.6.0",
+        "@parcel/utils": "2.6.0",
         "@parcel/watcher": "^2.0.0",
-        "@parcel/workers": "2.4.1"
+        "@parcel/workers": "2.6.0"
       }
     },
     "@parcel/fs-search": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@parcel/fs-search/-/fs-search-2.4.1.tgz",
-      "integrity": "sha512-xfoLvHjHkZm4VZf3UWU5v6gzz+x7IBVY7siHGn0YyGwvlv73FmiR4mCSizqerXOyXknF2fpg6tNHNQyyNLS32Q==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/fs-search/-/fs-search-2.6.0.tgz",
+      "integrity": "sha512-1nXzM3H/cA4kzLKvDBvwmNisKCdRqlgkLXh+OR1Zu28Kn4W34KuJMcHWW8cC+WIuuKqDh5oo2WPsC5y65GXBKQ==",
       "requires": {
         "detect-libc": "^1.0.3"
       }
     },
     "@parcel/graph": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@parcel/graph/-/graph-2.4.1.tgz",
-      "integrity": "sha512-3JCnPI9BJdKpGIk6NtVN7ML3C/J9Ey+WfUfk8WisDxFP7vjYkXwZbNSR/HnxH+Y03wmB6cv4HI8A4kndF0H0pw==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/graph/-/graph-2.6.0.tgz",
+      "integrity": "sha512-rxrAzWm6rwbCRPbu0Z+zwMscpG8omffODniVWPlX2G0jgQGpjKsutBQ6RMfFIcfaQ4MzL3pIQOTf8bkjQOPsbg==",
       "requires": {
-        "@parcel/utils": "2.4.1",
+        "@parcel/utils": "2.6.0",
         "nullthrows": "^1.1.1"
       }
     },
     "@parcel/hash": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@parcel/hash/-/hash-2.4.1.tgz",
-      "integrity": "sha512-Ch1kkFPedef3geapU+XYmAdZY29u3eQXn/twMjowAKkWCmj6wZ+muUgBmOO2uCfK3xys7GycI8jYZcAbF5DVLg==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/hash/-/hash-2.6.0.tgz",
+      "integrity": "sha512-YugWqhLxqK80Lo++3B3Kr5UPCHOdS8iI2zJ1jkzUeH9v6WUzbwWOnmPf6lN2S5m1BrIFFJd8Jc+CbEXWi8zoJA==",
       "requires": {
         "detect-libc": "^1.0.3",
         "xxhash-wasm": "^0.4.2"
       }
     },
     "@parcel/logger": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.4.1.tgz",
-      "integrity": "sha512-wm7FoKY+1dyo+Dd7Z4b0d6hmpgRBWfZwCoZSSyhgbG96Ty68/oo3m7oEMXPfry8IVGIhShmWKDp4py44PH3l7w==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.6.0.tgz",
+      "integrity": "sha512-J1/7kPfSGBvMKSZdi0WCNuN0fIeiWxifnDGn7W/K8KhD422YwFJA8N046ps8nkDOPIXf1osnIECNp4GIR9oSYw==",
       "requires": {
-        "@parcel/diagnostic": "2.4.1",
-        "@parcel/events": "2.4.1"
+        "@parcel/diagnostic": "2.6.0",
+        "@parcel/events": "2.6.0"
       }
     },
     "@parcel/markdown-ansi": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@parcel/markdown-ansi/-/markdown-ansi-2.4.1.tgz",
-      "integrity": "sha512-BkWhzbKQhTQ9lS96ZMMG0KyXSJBFdNeBVobWrdrrwcFlNER0nt2m6fdF7Hfpf1TqFhM4tT+GNFtON7ybL53RiQ==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/markdown-ansi/-/markdown-ansi-2.6.0.tgz",
+      "integrity": "sha512-fyjkrJQQSfKTUFTTasdZ6WrAkDoQ2+DYDjj+3p+RncYyrIa9zArKx4IiRiipsvNdtMvP0/hTdK8F3BOJ3KSU/g==",
       "requires": {
         "chalk": "^4.1.0"
       },
@@ -26109,49 +26321,49 @@
       }
     },
     "@parcel/namer-default": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@parcel/namer-default/-/namer-default-2.4.1.tgz",
-      "integrity": "sha512-a/Xulfia7JJP6Cw/D6Wq5xX6IAKVKMRPEYtU2wB8vKuwC/et6kXi+0bFVeCLnTjDzVtsjDdyOEwfRC4yiEy3BA==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/namer-default/-/namer-default-2.6.0.tgz",
+      "integrity": "sha512-r8O12r7ozJBctnFxVdXbf/fK97GIdNj3hiiUNWlXEmED9sw6ZPcChaLcfot0/443g8i87JDmSTKJ8js2tuz5XA==",
       "requires": {
-        "@parcel/diagnostic": "2.4.1",
-        "@parcel/plugin": "2.4.1",
+        "@parcel/diagnostic": "2.6.0",
+        "@parcel/plugin": "2.6.0",
         "nullthrows": "^1.1.1"
       }
     },
     "@parcel/node-resolver-core": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@parcel/node-resolver-core/-/node-resolver-core-2.4.1.tgz",
-      "integrity": "sha512-CvCADj3l4o5USqz/ZCaqbK8gdAQK63q94oSa0KnP6hrcDI/gDyf5Bk4+3cD4kSI+ByuN6aFLAYBS2nHBh5O/MQ==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/node-resolver-core/-/node-resolver-core-2.6.0.tgz",
+      "integrity": "sha512-AJDj5DZbB58plv0li8bdVSD+zpnkHE36Om3TYyNn1jgXXwgBM64Er/9p8yQn356jBqTQMh7zlJqvbdIyOiMeMg==",
       "requires": {
-        "@parcel/diagnostic": "2.4.1",
-        "@parcel/utils": "2.4.1",
+        "@parcel/diagnostic": "2.6.0",
+        "@parcel/utils": "2.6.0",
         "nullthrows": "^1.1.1"
       }
     },
     "@parcel/optimizer-terser": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@parcel/optimizer-terser/-/optimizer-terser-2.4.1.tgz",
-      "integrity": "sha512-naRdp6gApWHUI1FCBZEJs9NzNngjZx8hRhIHeQtTxWpc2Mu8cVzxbVHNAwUj10nW3iOYmxyj4wleOArl8xpVCQ==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/optimizer-terser/-/optimizer-terser-2.6.0.tgz",
+      "integrity": "sha512-oezRt6Lz/QqcVDXyMfFjzQc7n0ThJowLJ4Lyhu8rMh0ZJYzc4UCFCw/19d4nRnzE+Qg0vj3mQCpdkA9/64E44g==",
       "requires": {
-        "@parcel/diagnostic": "2.4.1",
-        "@parcel/plugin": "2.4.1",
+        "@parcel/diagnostic": "2.6.0",
+        "@parcel/plugin": "2.6.0",
         "@parcel/source-map": "^2.0.0",
-        "@parcel/utils": "2.4.1",
+        "@parcel/utils": "2.6.0",
         "nullthrows": "^1.1.1",
         "terser": "^5.2.0"
       }
     },
     "@parcel/package-manager": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@parcel/package-manager/-/package-manager-2.4.1.tgz",
-      "integrity": "sha512-JUUinm4U3hy4epHl9A389xb+BGiFR8n9+qw3Z4UDfS1te43sh8+0virBGcnai/G7mlr5/vHW+l9xulc7WQaY6w==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/package-manager/-/package-manager-2.6.0.tgz",
+      "integrity": "sha512-AqFfdkbOw51q/3ia2mIsFTmrpYEyUb3k+2uYC5GsLMz3go6OGn7/Crz0lZLSclv5EtwpRg3TWr9yL7RekVN/Uw==",
       "requires": {
-        "@parcel/diagnostic": "2.4.1",
-        "@parcel/fs": "2.4.1",
-        "@parcel/logger": "2.4.1",
-        "@parcel/types": "2.4.1",
-        "@parcel/utils": "2.4.1",
-        "@parcel/workers": "2.4.1",
+        "@parcel/diagnostic": "2.6.0",
+        "@parcel/fs": "2.6.0",
+        "@parcel/logger": "2.6.0",
+        "@parcel/types": "2.6.0",
+        "@parcel/utils": "2.6.0",
+        "@parcel/workers": "2.6.0",
         "semver": "^5.7.1"
       },
       "dependencies": {
@@ -26163,23 +26375,23 @@
       }
     },
     "@parcel/packager-js": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@parcel/packager-js/-/packager-js-2.4.1.tgz",
-      "integrity": "sha512-broWBUQisJLF5ThFtnl/asypuLMlMBwFPBTr8Ho9FYlL6W4wUzIymu7eOcuDljstmbD6luNVGMdCBYqt3IhHmw==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/packager-js/-/packager-js-2.6.0.tgz",
+      "integrity": "sha512-Uz3pqIFchFfKszWnNGDgIwM1uwHHJp7Dts6VzS9lf/2RbRgZT0fmce+NPgnVO5MMKBHzdvm32ShT6gFAABF5Vw==",
       "requires": {
-        "@parcel/diagnostic": "2.4.1",
-        "@parcel/hash": "2.4.1",
-        "@parcel/plugin": "2.4.1",
+        "@parcel/diagnostic": "2.6.0",
+        "@parcel/hash": "2.6.0",
+        "@parcel/plugin": "2.6.0",
         "@parcel/source-map": "^2.0.0",
-        "@parcel/utils": "2.4.1",
+        "@parcel/utils": "2.6.0",
         "globals": "^13.2.0",
         "nullthrows": "^1.1.1"
       },
       "dependencies": {
         "globals": {
-          "version": "13.13.0",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-13.13.0.tgz",
-          "integrity": "sha512-EQ7Q18AJlPwp3vUDL4mKA0KXrXyNIQyWon6T6XQiBQF0XHvRsiCSrWmmeATpUzdJN2HhWZU6Pdl0a9zdep5p6A==",
+          "version": "13.15.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-13.15.0.tgz",
+          "integrity": "sha512-bpzcOlgDhMG070Av0Vy5Owklpv1I6+j96GhUI7Rh7IzDCKLzboflLrrfqMu8NquDbiR4EOQk7XzJwqVJxicxog==",
           "requires": {
             "type-fest": "^0.20.2"
           }
@@ -26187,97 +26399,105 @@
       }
     },
     "@parcel/packager-raw": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@parcel/packager-raw/-/packager-raw-2.4.1.tgz",
-      "integrity": "sha512-4lCY3TjiYaZyRIqshNF21i6XkQ5PJyr+ahhK4O2IymuYuD8/wGH2amTZqKPpGLuiF3j1HskRRUNv1ekpvExJ8w==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/packager-raw/-/packager-raw-2.6.0.tgz",
+      "integrity": "sha512-ktT6Qc/GgCq8H1+6y+AXufVzQj1s6KRoKf83qswCD0iY3MwCbJoEfc3IsB4K64FpHIL5Eu0z54IId+INvGbOYA==",
       "requires": {
-        "@parcel/plugin": "2.4.1"
+        "@parcel/plugin": "2.6.0"
       }
     },
     "@parcel/plugin": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@parcel/plugin/-/plugin-2.4.1.tgz",
-      "integrity": "sha512-EJzNhwNWYuSpIPRlG1U2hKcovq/RsVie4Os1z51/e2dcCto/uAoJOMoWYYsCxtjkJ7BjFYyQ7fcZRKM9DEr6gQ==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/plugin/-/plugin-2.6.0.tgz",
+      "integrity": "sha512-LzOaiK8R6eFEoov1cb3/W+o0XvXdI/VbDhMDl0L0II+/56M0UeayYtFP5QGTDn/fZqVlYfzPCtt3EMwdG7/dow==",
       "requires": {
-        "@parcel/types": "2.4.1"
+        "@parcel/types": "2.6.0"
       }
     },
     "@parcel/reporter-dev-server": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@parcel/reporter-dev-server/-/reporter-dev-server-2.4.1.tgz",
-      "integrity": "sha512-tRz1LHiudDhujBC3kJ3Qm0Wnbo3p3SpE6fjyCFRhdv2PJnEufNTTwzEUoa7lYZACwFVQUtrh6F7nMXFw6ynrsQ==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/reporter-dev-server/-/reporter-dev-server-2.6.0.tgz",
+      "integrity": "sha512-VvygsCA+uzWyijIV8zqU1gFyhAWknuaY4KIWhV4kCT8afRJwsLSwt/tpdaKDPuPU45h3tTsUdXH1wjaIk+dGeQ==",
       "requires": {
-        "@parcel/plugin": "2.4.1",
-        "@parcel/utils": "2.4.1"
+        "@parcel/plugin": "2.6.0",
+        "@parcel/utils": "2.6.0"
       }
     },
     "@parcel/resolver-default": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@parcel/resolver-default/-/resolver-default-2.4.1.tgz",
-      "integrity": "sha512-iJRt1+7lk0n7+wb+S/tVyiObbaiYP1YQGKRsTE8y4Kgp4/OPukdUHGFJwzbojWa0HnyoXm3zEgelVz7cHl47fQ==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/resolver-default/-/resolver-default-2.6.0.tgz",
+      "integrity": "sha512-ATk9wXvy5GOHAqyHbnCnU11fUPTtf8dLjpgVqL5XylwugZnyBXbynoTWX4w8h6mffkVtdfmzTJx/o4Lresz9sA==",
       "requires": {
-        "@parcel/node-resolver-core": "2.4.1",
-        "@parcel/plugin": "2.4.1"
+        "@parcel/node-resolver-core": "2.6.0",
+        "@parcel/plugin": "2.6.0"
       }
     },
     "@parcel/runtime-browser-hmr": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@parcel/runtime-browser-hmr/-/runtime-browser-hmr-2.4.1.tgz",
-      "integrity": "sha512-INsr78Kn0OuwMdXHCzw7v6l3Gf/UBTYtX7N7JNDOIBEFFkuZQiFWyAOI2P/DvMm8qeqcsrKliBO5Xty/a2Ivaw==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/runtime-browser-hmr/-/runtime-browser-hmr-2.6.0.tgz",
+      "integrity": "sha512-90xvv/10cFML5dAhClBEJZ/ExiBQVPqQsZcvRmVZmc5mpZVJMKattWCQrd7pAf7FDYl4JAcvsK3DTwvRT/oLNA==",
       "requires": {
-        "@parcel/plugin": "2.4.1",
-        "@parcel/utils": "2.4.1"
+        "@parcel/plugin": "2.6.0",
+        "@parcel/utils": "2.6.0"
       }
     },
     "@parcel/runtime-js": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@parcel/runtime-js/-/runtime-js-2.4.1.tgz",
-      "integrity": "sha512-/EXwRpo+GPvWgN5yD0hjjt84Gm6QWp757dqOOzTG5R2rm1WU+g1a+zJJB1zXkxhu9lleQs44D1jEffzhh2Voyw==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/runtime-js/-/runtime-js-2.6.0.tgz",
+      "integrity": "sha512-R4tJAIT/SX7VBQ+f7WmeekREQzzLsmgP1j486uKhQNyYrpvsN0HnRbg5aqvZjEjkEmSeJR0mOlWtMK5/m+0yTA==",
       "requires": {
-        "@parcel/plugin": "2.4.1",
-        "@parcel/utils": "2.4.1",
+        "@parcel/plugin": "2.6.0",
+        "@parcel/utils": "2.6.0",
         "nullthrows": "^1.1.1"
       }
     },
     "@parcel/runtime-react-refresh": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@parcel/runtime-react-refresh/-/runtime-react-refresh-2.4.1.tgz",
-      "integrity": "sha512-a4GBQ/fO7Mklh1M1G2JVpJBPbZD7YXUPAzh9Y4vpCf0ouTHBRMc8ew4CyKPJIrrTly5P42tFWnD3P4FVNKwHOQ==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/runtime-react-refresh/-/runtime-react-refresh-2.6.0.tgz",
+      "integrity": "sha512-2sRd13gc2EbMV/O5n2NPVGGhKBasb1fDTXGEY8y7qi9xDKc+ewok/D83T+w243FhCPS9Pf3ur5GkbPlrJGcenQ==",
       "requires": {
-        "@parcel/plugin": "2.4.1",
-        "@parcel/utils": "2.4.1",
+        "@parcel/plugin": "2.6.0",
+        "@parcel/utils": "2.6.0",
+        "react-error-overlay": "6.0.9",
         "react-refresh": "^0.9.0"
+      },
+      "dependencies": {
+        "react-error-overlay": {
+          "version": "6.0.9",
+          "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.9.tgz",
+          "integrity": "sha512-nQTTcUu+ATDbrSD1BZHr5kgSD4oF8OFjxun8uAaL8RwPBacGBNPf/yAuVVdx17N8XNzRDMrZ9XcKZHCjPW+9ew=="
+        }
       }
     },
     "@parcel/runtime-service-worker": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@parcel/runtime-service-worker/-/runtime-service-worker-2.4.1.tgz",
-      "integrity": "sha512-WtMKSiyQ0kF78rBw0XIx7n65mMb+6GBx+5m49r1aVZzeZEOSynpjJzJvqo7rxVmA7qTDkD2bko7BH41iScsEaw==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/runtime-service-worker/-/runtime-service-worker-2.6.0.tgz",
+      "integrity": "sha512-nVlknGw5J5Bkd1Wr1TbyWHhUd9CmVVebaRg/lpfVKYhAuE/2r+3N0+J8qbEIgtTRcHaSV7wTNpg4weSWq46VeA==",
       "requires": {
-        "@parcel/plugin": "2.4.1",
-        "@parcel/utils": "2.4.1",
+        "@parcel/plugin": "2.6.0",
+        "@parcel/utils": "2.6.0",
         "nullthrows": "^1.1.1"
       }
     },
     "@parcel/source-map": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@parcel/source-map/-/source-map-2.0.2.tgz",
-      "integrity": "sha512-NnUrPYLpYB6qyx2v6bcRPn/gVigmGG6M6xL8wIg/i0dP1GLkuY1nf+Hqdf63FzPTqqT7K3k6eE5yHPQVMO5jcA==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@parcel/source-map/-/source-map-2.0.5.tgz",
+      "integrity": "sha512-DRVlCFKLpqBSIbMxUoVlHgfiv12HTW/U7nnhzw52YgzDVXUX9OA41dXS1PU0pJ1si+D1k8msATUC+AoldN43mg==",
       "requires": {
         "detect-libc": "^1.0.3"
       }
     },
     "@parcel/transformer-js": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-js/-/transformer-js-2.4.1.tgz",
-      "integrity": "sha512-39Y9RUuDk5dc09Z3Pgj8snQd5E8926IqOowdTLKNJr7EcmkwHdinbpI4EqgKnisOwX4NSzxUti1I2DHsP1QZHw==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-js/-/transformer-js-2.6.0.tgz",
+      "integrity": "sha512-4v2r3EVdMKowBziVBW9HZqvAv88HaeiezkWyMX4wAfplo9jBtWEp99KEQINzSEdbXROR81M9oJjlGF5+yoVr/w==",
       "requires": {
-        "@parcel/diagnostic": "2.4.1",
-        "@parcel/plugin": "2.4.1",
+        "@parcel/diagnostic": "2.6.0",
+        "@parcel/plugin": "2.6.0",
         "@parcel/source-map": "^2.0.0",
-        "@parcel/utils": "2.4.1",
-        "@parcel/workers": "2.4.1",
-        "@swc/helpers": "^0.3.6",
+        "@parcel/utils": "2.6.0",
+        "@parcel/workers": "2.6.0",
+        "@swc/helpers": "^0.3.15",
         "browserslist": "^4.6.6",
         "detect-libc": "^1.0.3",
         "nullthrows": "^1.1.1",
@@ -26293,56 +26513,56 @@
       }
     },
     "@parcel/transformer-json": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-json/-/transformer-json-2.4.1.tgz",
-      "integrity": "sha512-bAwKyWb2/Wm6GS7OpQg1lWgcq+VDBXTKy5oFGX3edbpZFsrb59Ln1v+1jI888zRq4ehDBybhx8WTxPKTJnU+jA==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-json/-/transformer-json-2.6.0.tgz",
+      "integrity": "sha512-zb+TQAdHWdXijKcFhLe+5KN1O0IzXwW1gJhPr8DJEA3qhPaCsncsw5RCVjQlP3a7NXr1mMm1eMtO6bhIMqbXeA==",
       "requires": {
-        "@parcel/plugin": "2.4.1",
+        "@parcel/plugin": "2.6.0",
         "json5": "^2.2.0"
       }
     },
     "@parcel/transformer-raw": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-raw/-/transformer-raw-2.4.1.tgz",
-      "integrity": "sha512-0PzdWJSGSTQ522aohymHEnq4GABy0mHSs+LkPZyMfNmX9ZAIyy6XuFJ9dz8nUmP4Nhn8qDvbRjoAYXR3XsGDGQ==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-raw/-/transformer-raw-2.6.0.tgz",
+      "integrity": "sha512-QDirlWCS/qy0DQ3WvDIAnFP52n1TJW/uWH+4PGMNnX4/M3/2UchY8xp9CN0tx4NQ4g09S8o3gLlHvNxQqZxFrQ==",
       "requires": {
-        "@parcel/plugin": "2.4.1"
+        "@parcel/plugin": "2.6.0"
       }
     },
     "@parcel/transformer-react-refresh-wrap": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-react-refresh-wrap/-/transformer-react-refresh-wrap-2.4.1.tgz",
-      "integrity": "sha512-zF6pzj/BwSiD1jA/BHDCEJnKSIDekjblU+OWp1WpSjA1uYkJORuZ5knLcq6mXOQ8M2NCbOXosc1ru8071i8sYA==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/transformer-react-refresh-wrap/-/transformer-react-refresh-wrap-2.6.0.tgz",
+      "integrity": "sha512-G34orfvLDUTumuerqNmA8T8NUHk+R0jwUjbVPO7gpB6VCVQ5ocTABdE9vN9Uu/cUsHij40TUFwqK4R9TFEBIEQ==",
       "requires": {
-        "@parcel/plugin": "2.4.1",
-        "@parcel/utils": "2.4.1",
+        "@parcel/plugin": "2.6.0",
+        "@parcel/utils": "2.6.0",
         "react-refresh": "^0.9.0"
       }
     },
     "@parcel/types": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@parcel/types/-/types-2.4.1.tgz",
-      "integrity": "sha512-YqkiyGS8oiD89Z2lJP7sbjn0F0wlSJMAuqgqf7obeKj0zmZJS7n2xK0uUEuIlUO+Cbqgl0kCGsUSjuT8xcEqjg==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/types/-/types-2.6.0.tgz",
+      "integrity": "sha512-lAMYvOBfNEJMsPJ+plbB50305o0TwNrY1xX5RRIWBqwOa6bYmbW1ZljUk1tQvnkpIE4eAHQwnPR5Z2XWg18wGQ==",
       "requires": {
-        "@parcel/cache": "2.4.1",
-        "@parcel/diagnostic": "2.4.1",
-        "@parcel/fs": "2.4.1",
-        "@parcel/package-manager": "2.4.1",
+        "@parcel/cache": "2.6.0",
+        "@parcel/diagnostic": "2.6.0",
+        "@parcel/fs": "2.6.0",
+        "@parcel/package-manager": "2.6.0",
         "@parcel/source-map": "^2.0.0",
-        "@parcel/workers": "2.4.1",
+        "@parcel/workers": "2.6.0",
         "utility-types": "^3.10.0"
       }
     },
     "@parcel/utils": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.4.1.tgz",
-      "integrity": "sha512-hmbrnPtFAfMT6s9FMMIVlIzCwEFX/+byB67GoJmSCAMRmj6RMu4a6xKlv2FdzkTKJV2ucg8vxAcua0MQ/q8rkQ==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.6.0.tgz",
+      "integrity": "sha512-ElXz+QHtT1JQIucbQJBk7SzAGoOlBp4yodEQVvTKS7GA+hEGrSP/cmibl6qm29Rjtd0zgQsdd+2XmP3xvP2gQQ==",
       "requires": {
-        "@parcel/codeframe": "2.4.1",
-        "@parcel/diagnostic": "2.4.1",
-        "@parcel/hash": "2.4.1",
-        "@parcel/logger": "2.4.1",
-        "@parcel/markdown-ansi": "2.4.1",
+        "@parcel/codeframe": "2.6.0",
+        "@parcel/diagnostic": "2.6.0",
+        "@parcel/hash": "2.6.0",
+        "@parcel/logger": "2.6.0",
+        "@parcel/markdown-ansi": "2.6.0",
         "@parcel/source-map": "^2.0.0",
         "chalk": "^4.1.0"
       },
@@ -26402,14 +26622,14 @@
       }
     },
     "@parcel/workers": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@parcel/workers/-/workers-2.4.1.tgz",
-      "integrity": "sha512-EYujbJOblFqIt2NGQ+baIYTuavJqbhy84IfZ3j0jmACeKO5Ew1EHXZyl9LJgWHKaIPZsnvnbxw2mDOF05K65xQ==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/workers/-/workers-2.6.0.tgz",
+      "integrity": "sha512-3tcI2LF5fd/WZtSnSjyWdDE+G+FitdNrRgSObzSp+axHKMAM23sO0z7KY8s2SYCF40msdYbFUW8eI6JlYNJoWQ==",
       "requires": {
-        "@parcel/diagnostic": "2.4.1",
-        "@parcel/logger": "2.4.1",
-        "@parcel/types": "2.4.1",
-        "@parcel/utils": "2.4.1",
+        "@parcel/diagnostic": "2.6.0",
+        "@parcel/logger": "2.6.0",
+        "@parcel/types": "2.6.0",
+        "@parcel/utils": "2.6.0",
         "chrome-trace-event": "^1.0.2",
         "nullthrows": "^1.1.1"
       }
@@ -26501,9 +26721,19 @@
       }
     },
     "@swc/helpers": {
-      "version": "0.3.8",
-      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.3.8.tgz",
-      "integrity": "sha512-aWItSZvJj4+GI6FWkjZR13xPNPctq2RRakzo+O6vN7bC2yjwdg5EFpgaSAUn95b7BGSgcflvzVDPoKmJv24IOg=="
+      "version": "0.3.17",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.3.17.tgz",
+      "integrity": "sha512-tb7Iu+oZ+zWJZ3HJqwx8oNwSDIU440hmVMDPhpACWQWnrZHK99Bxs70gT1L2dnr5Hg50ZRWEFkQCAnOVVV0z1Q==",
+      "requires": {
+        "tslib": "^2.4.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+        }
+      }
     },
     "@szmarczak/http-timer": {
       "version": "4.0.6",
@@ -27261,7 +27491,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
       "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
-      "dev": true,
       "requires": {
         "clean-stack": "^2.0.0",
         "indent-string": "^4.0.0"
@@ -28441,8 +28670,7 @@
     "clean-stack": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
-      "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
-      "dev": true
+      "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A=="
     },
     "cli-boxes": {
       "version": "2.2.1",
@@ -28636,7 +28864,7 @@
     "clone": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
-      "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18="
+      "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w=="
     },
     "clone-deep": {
       "version": "4.0.1",
@@ -29419,6 +29647,55 @@
         "isobject": "^3.0.1"
       }
     },
+    "del": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/del/-/del-5.1.0.tgz",
+      "integrity": "sha512-wH9xOVHnczo9jN2IW68BabcecVPxacIA3g/7z6vhSU/4stOKQzeCRK0yD0A24WiAAUJmmVpWqrERcTxnLo3AnA==",
+      "requires": {
+        "globby": "^10.0.1",
+        "graceful-fs": "^4.2.2",
+        "is-glob": "^4.0.1",
+        "is-path-cwd": "^2.2.0",
+        "is-path-inside": "^3.0.1",
+        "p-map": "^3.0.0",
+        "rimraf": "^3.0.0",
+        "slash": "^3.0.0"
+      },
+      "dependencies": {
+        "@types/glob": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.2.0.tgz",
+          "integrity": "sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==",
+          "requires": {
+            "@types/minimatch": "*",
+            "@types/node": "*"
+          }
+        },
+        "globby": {
+          "version": "10.0.2",
+          "resolved": "https://registry.npmjs.org/globby/-/globby-10.0.2.tgz",
+          "integrity": "sha512-7dUi7RvCoT/xast/o/dLN53oqND4yk0nsHkhRgn9w65C4PofCLOoJ39iSOg+qVDdWQPIEj+eszMHQ+aLVwwQSg==",
+          "requires": {
+            "@types/glob": "^7.1.1",
+            "array-union": "^2.1.0",
+            "dir-glob": "^3.0.1",
+            "fast-glob": "^3.0.3",
+            "glob": "^7.1.3",
+            "ignore": "^5.1.1",
+            "merge2": "^1.2.3",
+            "slash": "^3.0.0"
+          }
+        },
+        "p-map": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/p-map/-/p-map-3.0.0.tgz",
+          "integrity": "sha512-d3qXVTF/s+W+CdJ5A29wywV2n8CQQYahlgz2bFiA+4eVNJbHJodPZ+/gXwPGh0bOqA+j8S+6+ckmvLGPk1QpxQ==",
+          "requires": {
+            "aggregate-error": "^3.0.0"
+          }
+        }
+      }
+    },
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -29450,7 +29727,7 @@
     "detect-libc": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
-      "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups="
+      "integrity": "sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg=="
     },
     "detect-port": {
       "version": "1.3.0",
@@ -31180,9 +31457,9 @@
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc="
     },
     "gatsby": {
-      "version": "4.11.3",
-      "resolved": "https://registry.npmjs.org/gatsby/-/gatsby-4.11.3.tgz",
-      "integrity": "sha512-NmdWedBvIgeJqR1klE16QvuJjyshqQBU2FiZBWlt3foJ7syXoF6Ab7Eb5JafWsm89ejZyePiI79aHSDraIuZQA==",
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/gatsby/-/gatsby-4.9.0.tgz",
+      "integrity": "sha512-wDCzcCx4hKMqldwuXoG8gQq2nkL7zSqoJXEqWK4nKp8PJKi5DgJxBteKMWOoLPYsaqGZ0ccZmYvp76/zjl2olQ==",
       "requires": {
         "@babel/code-frame": "^7.14.0",
         "@babel/core": "^7.15.5",
@@ -31195,7 +31472,7 @@
         "@gatsbyjs/reach-router": "^1.3.6",
         "@gatsbyjs/webpack-hot-middleware": "^2.25.2",
         "@nodelib/fs.walk": "^1.2.8",
-        "@parcel/core": "^2.3.2",
+        "@parcel/core": "^2.3.1",
         "@pmmmwh/react-refresh-webpack-plugin": "^0.4.3",
         "@types/http-proxy": "^1.17.7",
         "@typescript-eslint/eslint-plugin": "^4.33.0",
@@ -31209,8 +31486,8 @@
         "babel-plugin-add-module-exports": "^1.0.4",
         "babel-plugin-dynamic-import-node": "^2.3.3",
         "babel-plugin-lodash": "^3.3.4",
-        "babel-plugin-remove-graphql-queries": "^4.11.1",
-        "babel-preset-gatsby": "^2.11.1",
+        "babel-plugin-remove-graphql-queries": "^4.9.0",
+        "babel-preset-gatsby": "^2.9.0",
         "better-opn": "^2.1.1",
         "bluebird": "^3.7.2",
         "body-parser": "^1.19.0",
@@ -31229,6 +31506,7 @@
         "date-fns": "^2.25.0",
         "debug": "^3.2.7",
         "deepmerge": "^4.2.2",
+        "del": "^5.1.0",
         "detect-port": "^1.3.0",
         "devcert": "^1.2.0",
         "dotenv": "^8.6.0",
@@ -31252,22 +31530,21 @@
         "find-cache-dir": "^3.3.2",
         "fs-exists-cached": "1.0.0",
         "fs-extra": "^10.0.0",
-        "gatsby-cli": "^4.11.2",
-        "gatsby-core-utils": "^3.11.1",
-        "gatsby-graphiql-explorer": "^2.11.0",
-        "gatsby-legacy-polyfills": "^2.11.0",
-        "gatsby-link": "^4.11.1",
-        "gatsby-page-utils": "^2.11.1",
-        "gatsby-parcel-config": "^0.2.0",
-        "gatsby-plugin-page-creator": "^4.11.1",
-        "gatsby-plugin-typescript": "^4.11.1",
-        "gatsby-plugin-utils": "^3.5.1",
-        "gatsby-react-router-scroll": "^5.11.0",
-        "gatsby-sharp": "^0.5.0",
-        "gatsby-telemetry": "^3.11.1",
-        "gatsby-worker": "^1.11.0",
+        "gatsby-cli": "^4.9.0",
+        "gatsby-core-utils": "^3.9.0",
+        "gatsby-graphiql-explorer": "^2.9.0",
+        "gatsby-legacy-polyfills": "^2.9.0",
+        "gatsby-link": "^4.9.0",
+        "gatsby-page-utils": "^2.9.0",
+        "gatsby-parcel-config": "^0.0.1",
+        "gatsby-plugin-page-creator": "^4.9.0",
+        "gatsby-plugin-typescript": "^4.9.0",
+        "gatsby-plugin-utils": "^3.3.0",
+        "gatsby-react-router-scroll": "^5.9.0",
+        "gatsby-sharp": "^0.3.0",
+        "gatsby-telemetry": "^3.9.0",
+        "gatsby-worker": "^1.9.0",
         "glob": "^7.2.0",
-        "globby": "^11.1.0",
         "got": "^11.8.2",
         "graphql": "^15.7.2",
         "graphql-compose": "^9.0.7",
@@ -31280,7 +31557,7 @@
         "joi": "^17.4.2",
         "json-loader": "^0.5.7",
         "latest-version": "5.1.0",
-        "lmdb": "~2.2.3",
+        "lmdb": "2.2.1",
         "lodash": "^4.17.21",
         "md5-file": "^5.0.0",
         "meant": "^1.0.3",
@@ -31773,6 +32050,16 @@
             }
           }
         },
+        "gatsby-sharp": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/gatsby-sharp/-/gatsby-sharp-0.3.0.tgz",
+          "integrity": "sha512-lMrmtoJjpCGoxnZbaQjfcF6vARPWgONw9r8fqGkHag0iSfcGpj3IM+LRdXT/i1mhNPDeB6pKBm5CvY8sYIgD0A==",
+          "optional": true,
+          "requires": {
+            "@types/sharp": "^0.29.5",
+            "sharp": "^0.30.1"
+          }
+        },
         "glob-parent": {
           "version": "5.1.2",
           "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
@@ -31801,6 +32088,18 @@
           "requires": {
             "argparse": "^1.0.7",
             "esprima": "^4.0.0"
+          }
+        },
+        "lmdb": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/lmdb/-/lmdb-2.2.1.tgz",
+          "integrity": "sha512-tUlIjyJvbd4mqdotI9Xe+3PZt/jqPx70VKFDrKMYu09MtBWOT3y2PbuTajX+bJFDjbgLkQC0cTx2n6dithp/zQ==",
+          "requires": {
+            "msgpackr": "^1.5.4",
+            "nan": "^2.14.2",
+            "node-gyp-build": "^4.2.3",
+            "ordered-binary": "^1.2.4",
+            "weak-lru-cache": "^1.2.2"
           }
         },
         "lru-cache": {
@@ -32049,27 +32348,27 @@
       }
     },
     "gatsby-parcel-config": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/gatsby-parcel-config/-/gatsby-parcel-config-0.2.0.tgz",
-      "integrity": "sha512-BbsSm5O0R7IvCRLNSk3lBpkU8RtSOn8s7Ifa7bHF63PzTG1SUpBjwMF6301tCbvdSXWrP7n9dsfaXS6ex/TElQ==",
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/gatsby-parcel-config/-/gatsby-parcel-config-0.0.1.tgz",
+      "integrity": "sha512-HYmIVyGLc9J0ZsJDiz6/PpfBSvl1mIPzQiWaGnou1R6KjGxoIlyp7kFCj4yuBlQXecjQ+gG3BY/osBi7FPY1qw==",
       "requires": {
         "@gatsbyjs/parcel-namer-relative-to-cwd": "0.0.2",
-        "@parcel/bundler-default": "^2.3.2",
-        "@parcel/compressor-raw": "^2.3.2",
-        "@parcel/namer-default": "^2.3.2",
-        "@parcel/optimizer-terser": "^2.3.2",
-        "@parcel/packager-js": "^2.3.2",
-        "@parcel/packager-raw": "^2.3.2",
-        "@parcel/reporter-dev-server": "^2.3.2",
-        "@parcel/resolver-default": "^2.3.2",
-        "@parcel/runtime-browser-hmr": "^2.3.2",
-        "@parcel/runtime-js": "^2.3.2",
-        "@parcel/runtime-react-refresh": "^2.3.2",
-        "@parcel/runtime-service-worker": "^2.3.2",
-        "@parcel/transformer-js": "^2.3.2",
-        "@parcel/transformer-json": "^2.3.2",
-        "@parcel/transformer-raw": "^2.3.2",
-        "@parcel/transformer-react-refresh-wrap": "^2.3.2"
+        "@parcel/bundler-default": "^2.3.1",
+        "@parcel/compressor-raw": "^2.3.1",
+        "@parcel/namer-default": "^2.3.1",
+        "@parcel/optimizer-terser": "^2.3.1",
+        "@parcel/packager-js": "^2.3.1",
+        "@parcel/packager-raw": "^2.3.1",
+        "@parcel/reporter-dev-server": "^2.3.1",
+        "@parcel/resolver-default": "^2.3.1",
+        "@parcel/runtime-browser-hmr": "^2.3.1",
+        "@parcel/runtime-js": "^2.3.1",
+        "@parcel/runtime-react-refresh": "^2.3.1",
+        "@parcel/runtime-service-worker": "^2.3.1",
+        "@parcel/transformer-js": "^2.3.1",
+        "@parcel/transformer-json": "^2.3.1",
+        "@parcel/transformer-raw": "^2.3.1",
+        "@parcel/transformer-react-refresh-wrap": "^2.3.1"
       }
     },
     "gatsby-plugin-canonical-urls": {
@@ -33883,6 +34182,11 @@
       "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
       "integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w=="
     },
+    "is-path-cwd": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-2.2.0.tgz",
+      "integrity": "sha512-w942bTcih8fdJPJmQHFzkS76NEP8Kzzvmw92cXsazb8intwLqPibPPdXf4ANdKV3rYMuuQYGIWtvz9JilB3NFQ=="
+    },
     "is-path-inside": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
@@ -34370,16 +34674,66 @@
       }
     },
     "lmdb": {
-      "version": "2.2.6",
-      "resolved": "https://registry.npmjs.org/lmdb/-/lmdb-2.2.6.tgz",
-      "integrity": "sha512-UmQV0oZZcV3EN6rjcAjIiuWcc3MYZGWQ0GUYz46Ron5fuTa/dUow7WSQa6leFkvZIKVUdECBWVw96tckfEzUFQ==",
+      "version": "2.3.10",
+      "resolved": "https://registry.npmjs.org/lmdb/-/lmdb-2.3.10.tgz",
+      "integrity": "sha512-GtH+nStn9V59CfYeQ5ddx6YTfuFCmu86UJojIjJAweG+/Fm0PDknuk3ovgYDtY/foMeMdZa8/P7oSljW/d5UPw==",
       "requires": {
+        "lmdb-darwin-arm64": "2.3.10",
+        "lmdb-darwin-x64": "2.3.10",
+        "lmdb-linux-arm": "2.3.10",
+        "lmdb-linux-arm64": "2.3.10",
+        "lmdb-linux-x64": "2.3.10",
+        "lmdb-win32-x64": "2.3.10",
         "msgpackr": "^1.5.4",
         "nan": "^2.14.2",
-        "node-gyp-build": "^4.2.3",
+        "node-addon-api": "^4.3.0",
+        "node-gyp-build-optional-packages": "^4.3.2",
         "ordered-binary": "^1.2.4",
         "weak-lru-cache": "^1.2.2"
+      },
+      "dependencies": {
+        "node-addon-api": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-4.3.0.tgz",
+          "integrity": "sha512-73sE9+3UaLYYFmDsFZnqCInzPyh3MqIwZO9cw58yIqAZhONrrabrYyYe3TuIqtIiOuTXVhsGau8hcrhhwSsDIQ=="
+        }
       }
+    },
+    "lmdb-darwin-arm64": {
+      "version": "2.3.10",
+      "resolved": "https://registry.npmjs.org/lmdb-darwin-arm64/-/lmdb-darwin-arm64-2.3.10.tgz",
+      "integrity": "sha512-LVXbH2MYu7/ZuQ8+P9rv+SwNyBKltxo7vHAGJS94HWyfwnCbKEYER9PImBvNBwzvgtaYk6x0RMX3oor6e6KdDQ==",
+      "optional": true
+    },
+    "lmdb-darwin-x64": {
+      "version": "2.3.10",
+      "resolved": "https://registry.npmjs.org/lmdb-darwin-x64/-/lmdb-darwin-x64-2.3.10.tgz",
+      "integrity": "sha512-gAc/1b/FZOb9yVOT+o0huA+hdW82oxLo5r22dFTLoRUFG1JMzxdTjmnW6ONVOHdqC9a5bt3vBCEY3jmXNqV26A==",
+      "optional": true
+    },
+    "lmdb-linux-arm": {
+      "version": "2.3.10",
+      "resolved": "https://registry.npmjs.org/lmdb-linux-arm/-/lmdb-linux-arm-2.3.10.tgz",
+      "integrity": "sha512-Rb8+4JjsThuEcJ7GLLwFkCFnoiwv/3hAAbELWITz70buQFF+dCZvCWWgEgmDTxwn5r+wIkdUjmFv4dqqiKQFmQ==",
+      "optional": true
+    },
+    "lmdb-linux-arm64": {
+      "version": "2.3.10",
+      "resolved": "https://registry.npmjs.org/lmdb-linux-arm64/-/lmdb-linux-arm64-2.3.10.tgz",
+      "integrity": "sha512-Ihr8mdICTK3jA4GXHxrXGK2oekn0mY6zuDSXQDNtyRSH19j3D2Y04A7SEI9S0EP/t5sjKSudYgZbiHDxRCsI5A==",
+      "optional": true
+    },
+    "lmdb-linux-x64": {
+      "version": "2.3.10",
+      "resolved": "https://registry.npmjs.org/lmdb-linux-x64/-/lmdb-linux-x64-2.3.10.tgz",
+      "integrity": "sha512-E3l3pDiCA9uvnLf+t3qkmBGRO01dp1EHD0x0g0iRnfpAhV7wYbayJGfG93BUt22Tj3fnq4HDo4dQ6ZWaDI1nuw==",
+      "optional": true
+    },
+    "lmdb-win32-x64": {
+      "version": "2.3.10",
+      "resolved": "https://registry.npmjs.org/lmdb-win32-x64/-/lmdb-win32-x64-2.3.10.tgz",
+      "integrity": "sha512-gspWk34tDANhjn+brdqZstJMptGiwj4qFNVg0Zey9ds+BUlif+Lgf5szrfOVzZ8gVRkk1Lgbz7i78+V7YK7SCA==",
+      "optional": true
     },
     "load-bmfont": {
       "version": "1.4.1",
@@ -35385,8 +35739,7 @@
     "node-gyp-build-optional-packages": {
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/node-gyp-build-optional-packages/-/node-gyp-build-optional-packages-4.3.2.tgz",
-      "integrity": "sha512-P5Ep3ISdmwcCkZIaBaQamQtWAG0facC89phWZgi5Z3hBU//J6S48OIvyZWSPPf6yQMklLZiqoosWAZUj7N+esA==",
-      "optional": true
+      "integrity": "sha512-P5Ep3ISdmwcCkZIaBaQamQtWAG0facC89phWZgi5Z3hBU//J6S48OIvyZWSPPf6yQMklLZiqoosWAZUj7N+esA=="
     },
     "node-object-hash": {
       "version": "2.3.10",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@fortawesome/react-fontawesome": "^0.1.16",
     "@mdx-js/mdx": "^1.6.22",
     "@mdx-js/react": "^1.6.22",
-    "gatsby": "^4.4.0",
+    "gatsby": "^4.9.0",
     "gatsby-plugin-canonical-urls": "^4.11.0",
     "gatsby-plugin-disqus": "^1.2.3",
     "gatsby-plugin-google-fonts": "^1.0.1",


### PR DESCRIPTION
## What is this PR? 🔍
### Problem

gatsby에 typescript를 적용해서 사용하고 있었는 데,
갑자기 npm run develop을 하자 아래와 같은 에러가 발생했다.

```bash
ERROR #10124  CONFIG

It looks like you were trying to add the config file? 
Please rename "gatsby-config.ts" to "gatsby-config.js"
```


### Solved

[공식문서](https://www.gatsbyjs.com/docs/how-to/custom-configuration/typescript/)를 살펴보니 `gatsby-config.ts`의 경우,
`gatsby@4.9.0`버전부터 지원한다고 되어있었다.(그동안은 왜 된거지..?)

<img width="597" alt="스크린샷 2022-06-06 오전 11 48 24" src="https://user-images.githubusercontent.com/54584063/172086296-d293f184-4ba0-47f3-8a7c-d7628286bd26.png">

gatsby 버전을 4.4.0->4.9.0로 업그레이드해서 해결했다.


## Issuse
#70